### PR TITLE
Colorized output on xterm-color

### DIFF
--- a/Source/Headers/CDRDefaultReporter.h
+++ b/Source/Headers/CDRDefaultReporter.h
@@ -5,6 +5,8 @@
 
     NSMutableArray *pendingMessages_;
     NSMutableArray *failureMessages_;
+
+    BOOL colorOutput_;
 }
 
 @end


### PR DESCRIPTION
Sam and I just added some color output when on xterm-color. 

We run our specs on the terminal frequently (mostly due to XCode ignoring our target selections) and wanted better visual feedback.
