### PR TITLE
Colorized output for Cedar with environment variable

### DIFF
--- a/Source/Headers/CDRDefaultReporter.h
+++ b/Source/Headers/CDRDefaultReporter.h
@@ -5,6 +5,8 @@
 
     NSMutableArray *pendingMessages_;
     NSMutableArray *failureMessages_;
+
+    BOOL colorOutput_;
 }
 
 @end


### PR DESCRIPTION
Provides good visual feedback when running our specs using rake on the terminal.
