### PR TITLE
Cedar updates for Xcode4

### DIFF
--- a/Cedar.xcodeproj/project.pbxproj
+++ b/Cedar.xcodeproj/project.pbxproj
@@ -705,7 +705,7 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
-			shellScript = "xcodebuild -project ${PROJECT_NAME}.xcodeproj -sdk iphonesimulator -target ${PROJECT_NAME}-StaticLib -configuration ${CONFIGURATION} clean build\nxcodebuild -project ${PROJECT_NAME}.xcodeproj -sdk iphoneos -target ${PROJECT_NAME}-StaticLib -configuration ${CONFIGURATION} clean build";
+			shellScript = "xcodebuild -project ${PROJECT_NAME}.xcodeproj -sdk iphonesimulator -target ${PROJECT_NAME}-StaticLib -configuration ${CONFIGURATION} clean build SYMROOT=${SYMROOT}\nxcodebuild -project ${PROJECT_NAME}.xcodeproj -sdk iphoneos -target ${PROJECT_NAME}-StaticLib -configuration ${CONFIGURATION} clean build SYMROOT=${SYMROOT}";
 		};
 		AEEE225A11DC2C0200029872 /* Build universal static lib */ = {
 			isa = PBXShellScriptBuildPhase;


### PR DESCRIPTION
I encountered 2 problems trying to build Cedar-iPhone under XCode 4.

First, it complained that iOS 4.2 wasn't around. This was fixed by dropping the '4.2' from 'iphone{os,simulator}4.2' in the Cedar-iPhone build scripts. It should now use the latest iOS SDK.

Second, the build scripts were always building into ~/build, no matter what my XCode build location preferences were set to. When running shell scripts in a Run Scripts build phase, the environment doesn't seem to get inherited, so xcodebuild was using ~/build as the default. By specifying SYMROOT=${SYMROOT}, xcodebuild now knows the right place to build, based on location preferences.
