### PR TITLE
Set navbar title to target's bundle display name.

### DIFF
--- a/Source/iPhone/CDRSpecStatusViewController.m
+++ b/Source/iPhone/CDRSpecStatusViewController.m
@@ -27,6 +27,12 @@
 #pragma mark View lifecycle
 - (void)viewDidLoad {
     [super viewDidLoad];
+
+    // Set the text of the label in the middle of the navigation bar to the test target's bundle
+    // display name, which Xcode defaults to ${PRODUCT_NAME}, i.e., whatever you enter for "Product
+    // Name," e.g., "Spec," when creating a new target. You can later change the "Product Name" from
+    // the target's Build Settings.
+    self.title = [[[NSBundle mainBundle] infoDictionary] objectForKey:@"CFBundleDisplayName"];
 }
 
 - (void)viewDidUnload {


### PR DESCRIPTION
I added this because when I first got the test target running, all I saw was a blank UINavigationController with a UITableViewController cause I didn't have any tests yet. So, I wasn't sure if I had set it up correctly until I added some tests. This might be a nice addition to include. We could also change it to always be `@"Cedar"`, but I thought this variable was nice because then it all maps out (like to your target name and directory name, etc.)

Thanks for the sweet stuff!

Matt

P.S. I'd like to add some more detail to the iPhone setup in README. Would you pull that in if I did that?
