### PR TITLE
Support selecting specs to run via CEDAR_SPECS env variable

### DIFF
--- a/Source/CDRFunctions.m
+++ b/Source/CDRFunctions.m
@@ -5,6 +5,7 @@
 #import "CDRExampleReporter.h"
 #import "CDRDefaultReporter.h"
 #import "SpecHelper.h"
+#import "CDRFunctions.h"
 
 BOOL CDRClassIsOfType(Class class, const char * const className) {
     if (strcmp(className, class_getName(class))) {
@@ -103,8 +104,24 @@ int runAllSpecs() {
     }
 
     id<CDRExampleReporter> reporter = [[[reporterClass alloc] init] autorelease];
-    int result = runSpecsWithCustomExampleReporter(NULL, reporter);
+    int result = runSpecsWithCustomExampleReporter(specClassesToRun(), reporter);
     [pool drain];
 
     return result;
+}
+
+NSArray *specClassesToRun() {
+    char *envSpecClassNames = getenv("CEDAR_SPECS");
+    NSMutableArray *specClassesToRun = nil;
+    if (envSpecClassNames) {
+        NSArray *specClassNames = [[NSString stringWithCString:envSpecClassNames encoding:NSUTF8StringEncoding] componentsSeparatedByCharactersInSet:[NSCharacterSet whitespaceCharacterSet]];
+        specClassesToRun = [NSMutableArray arrayWithCapacity:[specClassNames count]];
+        for(NSString *className in specClassNames) {
+            Class specClass = NSClassFromString(className);
+            if (specClass) {
+                [specClassesToRun addObject:specClass];
+            }
+        }
+    }
+    return [[specClassesToRun copy] autorelease];
 }

--- a/Source/Headers/CDRFunctions.h
+++ b/Source/Headers/CDRFunctions.h
@@ -5,3 +5,4 @@
 int runSpecsWithCustomExampleReporter(NSArray *specClasses, id<CDRExampleReporter> runner);
 int runAllSpecs();
 int runAllSpecsWithCustomExampleReporter(id<CDRExampleReporter> runner);
+NSArray *specClassesToRun();

--- a/Source/iPhone/CDRExampleReporterViewController.m
+++ b/Source/iPhone/CDRExampleReporterViewController.m
@@ -32,7 +32,9 @@
 }
 
 - (void)startSpecs {
-    runSpecsWithCustomExampleReporter(NULL, self);
+    NSAutoreleasePool *pool = [[NSAutoreleasePool alloc] init];
+    runSpecsWithCustomExampleReporter(specClassesToRun(), self);
+    [pool drain];
 }
 
 - (void)pushRootSpecStatusController:(NSArray *)groups {


### PR DESCRIPTION
Large sets of Cedar tests can take a while to run and I just want to focus on the specs for the class I am working on. Let's add a way to specify which specs to run:

`CEDAR_SPECS="SpecSpec SpecSpec2" rake specs`

Runs just those spec classes named in `CEDAR_SPECS`. Since this is just an env var we can specify it on the command line when running specs via rake or add it to our scheme when running specs via Xcode so it works in either environment and regardless of if we are running headless or not.
