### PR TITLE
added CEDAR_REPORTER_OPTS=nested to mimic rspec's specdoc/nested format

### DIFF
--- a/Source/CDRExampleBase.m
+++ b/Source/CDRExampleBase.m
@@ -45,10 +45,16 @@
 }
 
 - (NSString *)fullText {
+    return [[self fullTextInPieces] componentsJoinedByString:@" "];
+}
+
+- (NSMutableArray *)fullTextInPieces {
     if (self.parent && [self.parent hasFullText]) {
-        return [NSString stringWithFormat:@"%@ %@", [self.parent fullText], self.text];
+        NSMutableArray *array = [self.parent fullTextInPieces];
+        [array addObject:self.text];
+        return array;
     } else {
-        return self.text;
+        return [NSMutableArray arrayWithObject:self.text];
     }
 }
 

--- a/Source/Headers/CDRExampleBase.h
+++ b/Source/Headers/CDRExampleBase.h
@@ -35,6 +35,7 @@ typedef enum CDRExampleState CDRExampleState;
 
 - (NSString *)message;
 - (NSString *)fullText;
+- (NSMutableArray *)fullTextInPieces;
 @end
 
 @interface CDRExampleBase (RunReporting)

--- a/Source/Headers/CDRExampleParent.h
+++ b/Source/Headers/CDRExampleParent.h
@@ -10,5 +10,6 @@
 @optional
 - (BOOL)hasFullText;
 - (NSString *)fullText;
+- (NSMutableArray *)fullTextInPieces;
 
 @end

--- a/Spec/CDRExampleGroupSpec.mm
+++ b/Spec/CDRExampleGroupSpec.mm
@@ -515,7 +515,7 @@ describe(@"CDRExampleGroup", ^{
         });
     });
 
-    describe(@"fullText", ^{
+    describe(@"fullText/fullTextInPieces", ^{
         describe(@"with no parent", ^{
             beforeEach(^{
                 id<CDRExampleParent> parent = group.parent;
@@ -525,6 +525,11 @@ describe(@"CDRExampleGroup", ^{
             it(@"should return just its own text", ^{
                 NSString *fullText = group.fullText;
                 expect(fullText).to(equal(groupText));
+            });
+
+            it(@"should return just its own text in one piece", ^{
+                NSArray *fullTextPieces = group.fullTextInPieces;
+                expect([fullTextPieces isEqual:[NSArray arrayWithObject:groupText]]).to(be_truthy());
             });
         });
 
@@ -545,6 +550,11 @@ describe(@"CDRExampleGroup", ^{
                 expect(fullText).to(equal([NSString stringWithFormat:@"%@ %@", parentGroupText, groupText]));
             });
 
+            it(@"should return its parent's text pre-pended with its own text in pieces", ^{
+                NSArray *fullTextPieces = group.fullTextInPieces;
+                expect([fullTextPieces isEqual:[NSArray arrayWithObjects:parentGroupText, groupText, nil]]).to(be_truthy());
+            });
+
             describe(@"when the parent also has a parent", ^{
                 __block CDRExampleGroup *anotherGroup;
                 NSString *anotherGroupText = @"Another Group!";
@@ -557,6 +567,11 @@ describe(@"CDRExampleGroup", ^{
                 it(@"should include the text from all parents, pre-pended in the appopriate order", ^{
                     NSString *fullText = group.fullText;
                     expect(fullText).to(equal([NSString stringWithFormat:@"%@ %@ %@", anotherGroupText, parentGroupText, groupText]));
+                });
+
+                it(@"should include the text from all parents, pre-pended in the appopriate order in pieces", ^{
+                    NSArray *fullTextPieces = group.fullTextInPieces;
+                    expect([fullTextPieces isEqual:[NSArray arrayWithObjects:anotherGroupText, parentGroupText, groupText, nil]]).to(be_truthy());
                 });
             });
         });
@@ -579,6 +594,12 @@ describe(@"CDRExampleGroup", ^{
                 NSString *fullText = group.fullText;
                 NSString *text = group.text;
                 expect(fullText).to(equal(text));
+            });
+
+            it(@"should not include its parent's text in pieces", ^{
+                NSArray *fullTextPieces = group.fullTextInPieces;
+                NSString *text = group.text;
+                expect([fullTextPieces isEqual:[NSArray arrayWithObject:text]]).to(be_truthy());
             });
         });
     });

--- a/Spec/CDRExampleSpec.mm
+++ b/Spec/CDRExampleSpec.mm
@@ -48,6 +48,11 @@ CDRSharedExampleBlock sharedExampleMethod = [^(NSDictionary *context) {
             NSString *fullText = example.fullText;
             expect(fullText).to(equal(exampleText));
         });
+
+        it(@"should return just its own text in one piece", ^{
+            NSArray *fullTextPieces = example.fullTextInPieces;
+            expect([fullTextPieces isEqual:[NSArray arrayWithObject:exampleText]]).to(be_truthy());
+        });
     });
 
     describe(@"with a parent", ^{
@@ -69,6 +74,11 @@ CDRSharedExampleBlock sharedExampleMethod = [^(NSDictionary *context) {
             expect(fullText).to(equal([NSString stringWithFormat:@"%@ %@", groupText, exampleText]));
         });
 
+        it(@"should return its parent's text pre-pended with its own text in pieces", ^{
+            NSArray *fullTextPieces = example.fullTextInPieces;
+            expect([fullTextPieces isEqual:[NSArray arrayWithObjects:groupText, exampleText, nil]]).to(be_truthy());
+        });
+
         describe(@"when the parent also has a parent", ^{
             __block CDRExampleGroup *rootGroup;
             NSString *rootGroupText = @"Root!";
@@ -85,6 +95,11 @@ CDRSharedExampleBlock sharedExampleMethod = [^(NSDictionary *context) {
             it(@"should include the text from all parents, pre-pended in the appropriate order", ^{
                 NSString *fullText = example.fullText;
                 expect(fullText).to(equal([NSString stringWithFormat:@"%@ %@ %@", rootGroupText, groupText, exampleText]));
+            });
+
+            it(@"should include the text from all parents, pre-pended in the appopriate order in pieces", ^{
+                NSArray *fullTextPieces = example.fullTextInPieces;
+                expect([fullTextPieces isEqual:[NSArray arrayWithObjects:rootGroupText, groupText, exampleText, nil]]).to(be_truthy());
             });
         });
     });
@@ -103,6 +118,12 @@ CDRSharedExampleBlock sharedExampleMethod = [^(NSDictionary *context) {
 
         it(@"should not include its parent's text", ^{
             expect(example.fullText).to(equal(example.text));
+        });
+
+        it(@"should not include its parent's text in pieces", ^{
+            NSArray *fullTextPieces = example.fullTextInPieces;
+            NSString *text = example.text;
+            expect([fullTextPieces isEqual:[NSArray arrayWithObject:text]]).to(be_truthy());
         });
     });
 } copy];
@@ -330,7 +351,7 @@ describe(@"CDRExample", ^{
         });
     });
 
-    describe(@"fullText", ^{
+    describe(@"fullText/fullTextInPieces", ^{
         __block NSMutableDictionary *sharedExampleContext = [[NSMutableDictionary alloc] init];
 
         beforeEach(^{


### PR DESCRIPTION
Rspec lets us specify `--format=nested` (http://rspec.info/documentation/tools/spec.html) to print "code example doc strings with nested groups indented." Adding `CEDAR_REPORTER_OPTS=nested` should trigger similar behavior for Cedar (idea behind this env variable is to not replace `CEDAR_REPORTER_CLASS` but merely provide options for the selected reporter). 

Example output when using `CEDAR_REPORTER_CLASS=CDRColorizedReporter` and `CEDAR_REPORTER_OPTS=nested`:

```
   CDRExampleGroup
     hasChildren
       for an empty group
.        should return false
       for a non-empty group
P        should return true
     state
       for a group containing no examples
F        should be CDRExampleStatePending
       for a group containing at least one incomplete example
.        should be CDRExampleStateIncomplete
```
