### PR TITLE
Close button on CDRExampleDetailsViewController sometimes doesn't work.

### DIFF
--- a/Source/Headers/iPhone/CDRExampleDetailsViewController.h
+++ b/Source/Headers/iPhone/CDRExampleDetailsViewController.h
@@ -1,13 +1,20 @@
 #import <UIKit/UIKit.h>
 
+typedef void (^CDRExampleDetailsViewControllerCompletionHandler)(void);
+
 @class CDRExampleBase;
 
 @interface CDRExampleDetailsViewController : UIViewController {
     CDRExampleBase *example_;
     UINavigationBar *navigationBar_;
     UILabel *fullTextLabel_, *messageLabel_;
+    CDRExampleDetailsViewControllerCompletionHandler completion_;
 }
 
 - (id)initWithExample:(CDRExampleBase *)example;
+
+@property (nonatomic, copy) CDRExampleDetailsViewControllerCompletionHandler completion;
+           
+
 
 @end

--- a/Source/iPhone/CDRExampleDetailsViewController.m
+++ b/Source/iPhone/CDRExampleDetailsViewController.m
@@ -14,6 +14,8 @@ static const float TEXT_LABEL_MARGIN = 20.0;
 
 @implementation CDRExampleDetailsViewController
 
+@synthesize completion = _completion;
+
 - (id)initWithExample:(CDRExampleBase *)example {
     if (self = [super init]) {
         example_ = [example retain];
@@ -22,6 +24,7 @@ static const float TEXT_LABEL_MARGIN = 20.0;
 }
 
 - (void)dealloc {
+    [completion_ release];
     [example_ release];
     [self viewDidUnload];
     [super dealloc];
@@ -57,8 +60,10 @@ static const float TEXT_LABEL_MARGIN = 20.0;
 }
 
 #pragma mark Target actions
-- (void)closeWindow {
-    [self.parentViewController dismissModalViewControllerAnimated:YES];
+- (void)complete {
+    if (self.completion)
+        self.completion();
+    self.completion = nil;
 }
 
 #pragma mark Private interface
@@ -72,7 +77,7 @@ static const float TEXT_LABEL_MARGIN = 20.0;
     [navigationBar pushNavigationItem:navigationItem animated:NO];
     [navigationItem release];
 
-    UIBarButtonItem *closeButton = [[UIBarButtonItem alloc] initWithTitle:@"Close" style:UIBarButtonItemStylePlain target:self action:@selector(closeWindow)];
+    UIBarButtonItem *closeButton = [[UIBarButtonItem alloc] initWithTitle:@"Close" style:UIBarButtonItemStylePlain target:self action:@selector(complete)];
     navigationItem.rightBarButtonItem = closeButton;
     [closeButton release];
 

--- a/Source/iPhone/CDRSpecStatusViewController.m
+++ b/Source/iPhone/CDRSpecStatusViewController.m
@@ -72,6 +72,7 @@
         [self pushStatusViewForExamples:[selectedExample examples]];
     } else {
         CDRExampleDetailsViewController * exampleDetailsController = [[CDRExampleDetailsViewController alloc] initWithExample:selectedExample];
+        exampleDetailsController.completion = ^{ [self dismissModalViewControllerAnimated:YES]; };
         exampleDetailsController.modalTransitionStyle = UIModalTransitionStyleCoverVertical;
         [self presentModalViewController:exampleDetailsController animated:YES];
         [exampleDetailsController release];


### PR DESCRIPTION
The mechanism used in `CDRExampleDetailsViewController` -- accessing the `parentViewController` property to call `dismissModalViewControllerAnimated:` -- doesn't always work.  Occasionally, and for unknown reasons, the `parentViewContoller` property is nil.  

In general, I find it's better to dismiss view controllers in the same context from which they are presented.  (See  [Dismissing a modal view controller](http://developer.apple.com/library/ios/featuredarticles/ViewControllerPGforiPhoneOS/ModalViewControllers/ModalViewControllers.html)). This commit uses a block completion handler to accomplish this.  I could also rewrite using delegation, if blocks are not to your liking.
