### PR TITLE
allow writing be_nil, be_truthy, and be_empty matchers without parenthesis

### DIFF
--- a/Source/Headers/Matchers/Base/BeNil.h
+++ b/Source/Headers/Matchers/Base/BeNil.h
@@ -13,6 +13,7 @@ namespace Cedar { namespace Matchers {
         // Allow default copy ctor.
 
         virtual NSString * failure_message_end() const;
+        const BeNil & operator()() const;
 
         template<typename U>
         bool matches(const U &) const;
@@ -21,7 +22,7 @@ namespace Cedar { namespace Matchers {
         bool matches(U * const &) const;
     };
 
-    BeNil be_nil();
+    static const BeNil be_nil = BeNil();
 
 #pragma mark Generic
     template<typename U>

--- a/Source/Headers/Matchers/Base/BeTruthy.h
+++ b/Source/Headers/Matchers/Base/BeTruthy.h
@@ -12,12 +12,13 @@ namespace Cedar { namespace Matchers {
         // Allow default copy ctor.
 
         virtual NSString * failure_message_end() const;
+        const BeTruthy & operator()() const;
 
         template<typename U>
         bool matches(const U &) const;
     };
 
-    BeTruthy be_truthy();
+    static const BeTruthy be_truthy = BeTruthy();
 
 #pragma mark Generic
     template<typename U>

--- a/Source/Headers/Matchers/Container/BeEmpty.h
+++ b/Source/Headers/Matchers/Container/BeEmpty.h
@@ -10,6 +10,8 @@ namespace Cedar { namespace Matchers {
         ~BeEmpty();
         // Allow default copy ctor.
 
+        const BeEmpty & operator()() const;
+
         template<typename U>
         bool matches(const U &) const;
 
@@ -17,8 +19,11 @@ namespace Cedar { namespace Matchers {
         virtual NSString * failure_message_end() const;
     };
 
-    inline BeEmpty be_empty() {
-        return BeEmpty();
+    static const BeEmpty be_empty = BeEmpty();
+
+    // For backwards compatible parenthesis syntax
+    inline const BeEmpty & BeEmpty::operator()() const {
+        return *this;
     }
 
     inline BeEmpty::BeEmpty() : Base() {

--- a/Source/Matchers/BeNil.mm
+++ b/Source/Matchers/BeNil.mm
@@ -2,8 +2,9 @@
 
 namespace Cedar { namespace Matchers {
 
-    BeNil be_nil() {
-        return BeNil();
+    // For backwards compatible parenthesis syntax
+    const BeNil & BeNil::operator()() const {
+        return *this;
     }
 
     BeNil::BeNil() : Base() {

--- a/Source/Matchers/BeTruthy.mm
+++ b/Source/Matchers/BeTruthy.mm
@@ -2,8 +2,9 @@
 
 namespace Cedar { namespace Matchers {
 
-    BeTruthy be_truthy() {
-        return BeTruthy();
+    // For backwards compatible parenthesis syntax
+    const BeTruthy & BeTruthy::operator()() const {
+        return *this;
     }
 
     BeTruthy::BeTruthy() : Base() {

--- a/Spec/Matchers/Base/BeNilSpec.mm
+++ b/Spec/Matchers/Base/BeNilSpec.mm
@@ -116,4 +116,22 @@ describe(@"be_nil matcher", ^{
     });
 });
 
+describe(@"be_nil shorthand syntax (no parenthesis)", ^{
+    void *value = NULL;
+
+    describe(@"positive match", ^{
+        it(@"should should pass", ^{
+            expect(value).to(be_nil);
+        });
+    });
+
+    describe(@"negative match", ^{
+        it(@"should fail with a sensible failure message", ^{
+            expectFailureWithMessage(@"Expected <0> to not be nil", ^{
+                expect(value).to_not(be_nil);
+            });
+        });
+    });
+});
+
 SPEC_END

--- a/Spec/Matchers/Base/BeTruthySpec.mm
+++ b/Spec/Matchers/Base/BeTruthySpec.mm
@@ -104,4 +104,22 @@ describe(@"be_truthy matcher", ^{
     });
 });
 
+describe(@"be_truthy shorthand syntax (no parenthesis)", ^{
+    BOOL value = YES;
+
+    describe(@"positive match", ^{
+        it(@"should should pass", ^{
+            expect(value).to(be_truthy);
+        });
+    });
+
+    describe(@"negative match", ^{
+        it(@"should fail with a sensible failure message", ^{
+            expectFailureWithMessage(@"Expected <YES> to not evaluate to true", ^{
+                expect(value).to_not(be_truthy);
+            });
+        });
+    });
+});
+
 SPEC_END

--- a/Spec/Matchers/Container/BeEmptySpec.mm
+++ b/Spec/Matchers/Container/BeEmptySpec.mm
@@ -364,4 +364,22 @@ describe(@"be_empty matcher", ^{
     });
 });
 
+describe(@"be_empty shorthand syntax (no parenthesis)", ^{
+    NSArray *container = [NSArray array];
+
+    describe(@"positive match", ^{
+        it(@"should should pass", ^{
+            expect(container).to(be_empty);
+        });
+    });
+
+    describe(@"negative match", ^{
+        it(@"should fail with a sensible failure message", ^{
+            expectFailureWithMessage(@"Expected <(\n)> to not be empty", ^{
+                expect(container).to_not(be_empty);
+            });
+        });
+    });
+});
+
 SPEC_END


### PR DESCRIPTION
```
glass should be_empty;
```

instead of:

```
glass should be_empty();
```
