### PR TITLE
updated equal matcher to correctly behave with user defined objective-c classes

### DIFF
--- a/Source/Headers/Matchers/Comparators/CompareEqual.h
+++ b/Source/Headers/Matchers/Comparators/CompareEqual.h
@@ -3,43 +3,11 @@ namespace Cedar { namespace Matchers { namespace Comparators {
 #pragma mark Generic
     template<typename T, typename U>
     bool compare_equal(const T & actualValue, const U & expectedValue) {
-        return actualValue == expectedValue;
-    }
-
-#pragma mark id
-    template<typename U>
-    bool compare_equal(const id & actualValue, const U & expectedValue) {
-        return [actualValue isEqual:expectedValue];
-    }
-
-#pragma mark NSObject
-    template<typename U>
-    bool compare_equal(NSObject * const actualValue, const U & expectedValue) {
-        return [actualValue isEqual:expectedValue];
-    }
-
-#pragma mark NSString
-    template<typename U>
-    bool compare_equal(NSString * const actualValue, const U & expectedValue) {
-        return compare_equal(static_cast<const id &>(actualValue), expectedValue);
-    }
-
-#pragma mark NSMutableString
-    template<typename U>
-    bool compare_equal(NSMutableString * const actualValue, const U & expectedValue) {
-        return compare_equal(static_cast<NSString * const>(actualValue), expectedValue);
-    }
-
-#pragma mark NSArray
-    template<typename U>
-    bool compare_equal(NSArray * const actualValue, const U & expectedValue) {
-        return compare_equal(static_cast<const id &>(actualValue), expectedValue);
-    }    
-
-#pragma mark NSMutableArray
-    template<typename U>
-    bool compare_equal(NSMutableArray * const actualValue, const U & expectedValue) {
-        return compare_equal(static_cast<const id &>(actualValue), expectedValue);
+        if (strcmp(@encode(T), "@") == 0 && strcmp(@encode(U), "@") == 0) {
+            return [reinterpret_cast<const id &>(actualValue) isEqual:reinterpret_cast<const id &>(expectedValue)];
+        } else {
+            return actualValue == expectedValue;
+        }
     }
 
 #pragma mark NSNumber

--- a/Source/Headers/Matchers/Stringifiers/StringifiersBase.h
+++ b/Source/Headers/Matchers/Stringifiers/StringifiersBase.h
@@ -1,9 +1,13 @@
 namespace Cedar { namespace Matchers { namespace Stringifiers {
     template<typename U>
     NSString * string_for(const U & value) {
-        std::stringstream temp;
-        temp << value;
-        return [NSString stringWithCString:temp.str().c_str() encoding:NSUTF8StringEncoding];
+        if (strcmp(@encode(U), "@") == 0) {
+            return [reinterpret_cast<const id &>(value) description];
+        } else {
+            std::stringstream temp;
+            temp << value;
+            return [NSString stringWithCString:temp.str().c_str() encoding:NSUTF8StringEncoding];
+        }
     }
 
     inline NSString * string_for(const char value) {
@@ -14,27 +18,7 @@ namespace Cedar { namespace Matchers { namespace Stringifiers {
         return value ? @"YES" : @"NO";
     }
 
-    inline NSString * string_for(const id value) {
-        return [value description];
-    }
-
-    inline NSString * string_for(NSObject * const value) {
-        return string_for(static_cast<const id>(value));
-    }
-
-    inline NSString * string_for(NSValue * const value) {
-        return string_for(static_cast<const id>(value));
-    }
-
-    inline NSString * string_for(NSString * const value) {
-        return string_for(static_cast<const id>(value));
-    }
-
     inline NSString * string_for(NSNumber * const value) {
         return string_for([value floatValue]);
-    }
-
-    inline NSString * string_for(NSMutableString * const value) {
-        return string_for(static_cast<NSString * const>(value));
     }
 }}}

--- a/Spec/Matchers/Base/EqualSpec.mm
+++ b/Spec/Matchers/Base/EqualSpec.mm
@@ -12,6 +12,22 @@ extern "C" {
 
 using namespace Cedar::Matchers;
 
+@interface CustomObject : NSObject {
+    BOOL shouldEqual_;
+}
+@property (nonatomic, assign) BOOL shouldEqual;
+@end
+
+@implementation CustomObject
+@synthesize shouldEqual = shouldEqual_;
+- (BOOL)isEqual:(id)object {
+    return self.shouldEqual;
+}
+- (NSString *)description {
+    return @"CustomObject";
+}
+@end
+
 SPEC_BEGIN(EqualSpec)
 
 describe(@"equal matcher", ^{
@@ -982,21 +998,21 @@ describe(@"equal matcher", ^{
     describe(@"when the actual value is declared as an NSArray *", ^{
         NSString *arrayContents = @"Hello";
         NSArray *actualArray = [NSArray arrayWithObject:arrayContents];
-        
+
         describe(@"and the expected value is declared as an NSObject *", ^{
             __block NSObject *expectedArray;
-            
+
             describe(@"and the values are equal", ^{
                 beforeEach(^{
                     expectedArray = [[actualArray mutableCopy] autorelease];
                 });
-                
+
                 describe(@"positive match", ^{
                     it(@"should pass", ^{
                         expect(actualArray).to(equal(expectedArray));
                     });
                 });
-                
+
                 describe(@"negative match", ^{
                     it(@"should fail with a sensible failure message", ^{
                         expectFailureWithMessage(@"Expected <(\n    Hello\n)> to not equal <(\n    Hello\n)>", ^{
@@ -1005,12 +1021,12 @@ describe(@"equal matcher", ^{
                     });
                 });
             });
-            
+
             describe(@"and the values are not equal", ^{
                 beforeEach(^{
                     expectedArray = [NSArray arrayWithObject:@"goodbye"];
                 });
-                
+
                 describe(@"positive match", ^{
                     it(@"should fail with a sensible failure message", ^{
                         expectFailureWithMessage(@"Expected <(\n    Hello\n)> to equal <(\n    goodbye\n)>", ^{
@@ -1018,7 +1034,7 @@ describe(@"equal matcher", ^{
                         });
                     });
                 });
-                
+
                 describe(@"negative match", ^{
                     it(@"should pass", ^{
                         expect(actualArray).to_not(equal(expectedArray));
@@ -1026,21 +1042,21 @@ describe(@"equal matcher", ^{
                 });
             });
         });
-        
+
         describe(@"and the expected value is declared as an id", ^{
             __block id expectedArray;
-            
+
             describe(@"and the values are equal", ^{
                 beforeEach(^{
                     expectedArray = [[actualArray mutableCopy] autorelease];
                 });
-                
+
                 describe(@"positive match", ^{
                     it(@"should pass", ^{
                         expect(actualArray).to(equal(expectedArray));
                     });
                 });
-                
+
                 describe(@"negative match", ^{
                     it(@"should fail with a sensible failure message", ^{
                         expectFailureWithMessage(@"Expected <(\n    Hello\n)> to not equal <(\n    Hello\n)>", ^{
@@ -1049,12 +1065,12 @@ describe(@"equal matcher", ^{
                     });
                 });
             });
-            
+
             describe(@"and the values are not equal", ^{
                 beforeEach(^{
                     expectedArray = [NSArray arrayWithObject:@"goodbye"];
                 });
-                
+
                 describe(@"positive match", ^{
                     it(@"should fail with a sensible failure message", ^{
                         expectFailureWithMessage(@"Expected <(\n    Hello\n)> to equal <(\n    goodbye\n)>", ^{
@@ -1062,7 +1078,7 @@ describe(@"equal matcher", ^{
                         });
                     });
                 });
-                
+
                 describe(@"negative match", ^{
                     it(@"should pass", ^{
                         expect(actualArray).to_not(equal(expectedArray));
@@ -1073,18 +1089,18 @@ describe(@"equal matcher", ^{
 
         describe(@"and the expected value is declared as an NSArray *", ^{
             __block NSArray *expectedArray;
-            
+
             describe(@"and the values are equal", ^{
                 beforeEach(^{
                     expectedArray = [[actualArray mutableCopy] autorelease];
                 });
-                
+
                 describe(@"positive match", ^{
                     it(@"should pass", ^{
                         expect(actualArray).to(equal(expectedArray));
                     });
                 });
-                
+
                 describe(@"negative match", ^{
                     it(@"should fail with a sensible failure message", ^{
                         expectFailureWithMessage(@"Expected <(\n    Hello\n)> to not equal <(\n    Hello\n)>", ^{
@@ -1093,12 +1109,12 @@ describe(@"equal matcher", ^{
                     });
                 });
             });
-            
+
             describe(@"and the values are not equal", ^{
                 beforeEach(^{
                     expectedArray = [NSArray arrayWithObject:@"goodbye"];
                 });
-                
+
                 describe(@"positive match", ^{
                     it(@"should fail with a sensible failure message", ^{
                         expectFailureWithMessage(@"Expected <(\n    Hello\n)> to equal <(\n    goodbye\n)>", ^{
@@ -1106,7 +1122,7 @@ describe(@"equal matcher", ^{
                         });
                     });
                 });
-                
+
                 describe(@"negative match", ^{
                     it(@"should pass", ^{
                         expect(actualArray).to_not(equal(expectedArray));
@@ -1114,21 +1130,21 @@ describe(@"equal matcher", ^{
                 });
             });
         });
-        
+
         describe(@"and the expected value is declared as an NSMutableArray *", ^{
             __block NSMutableArray *expectedArray;
-            
+
             describe(@"and the values are equal", ^{
                 beforeEach(^{
                     expectedArray = [[actualArray mutableCopy] autorelease];
                 });
-                
+
                 describe(@"positive match", ^{
                     it(@"should pass", ^{
                         expect(actualArray).to(equal(expectedArray));
                     });
                 });
-                
+
                 describe(@"negative match", ^{
                     it(@"should fail with a sensible failure message", ^{
                         expectFailureWithMessage(@"Expected <(\n    Hello\n)> to not equal <(\n    Hello\n)>", ^{
@@ -1137,12 +1153,12 @@ describe(@"equal matcher", ^{
                     });
                 });
             });
-            
+
             describe(@"and the values are not equal", ^{
                 beforeEach(^{
                     expectedArray = [NSArray arrayWithObject:@"goodbye"];
                 });
-                
+
                 describe(@"positive match", ^{
                     it(@"should fail with a sensible failure message", ^{
                         expectFailureWithMessage(@"Expected <(\n    Hello\n)> to equal <(\n    goodbye\n)>", ^{
@@ -1150,10 +1166,66 @@ describe(@"equal matcher", ^{
                         });
                     });
                 });
-                
+
                 describe(@"negative match", ^{
                     it(@"should pass", ^{
                         expect(actualArray).to_not(equal(expectedArray));
+                    });
+                });
+            });
+        });
+    });
+
+    describe(@"custom objects (user-defined)", ^{
+        describe(@"with an actual value declared as CustomObject *", ^{
+            __block CustomObject *actualObject;
+
+            beforeEach(^{
+                actualObject = [[[CustomObject alloc] init] autorelease];
+            });
+
+            describe(@"and the expected value declared as CustomObject *", ^{
+                __block CustomObject *expectedObject;
+
+                describe(@"and the values are equal", ^{
+                    beforeEach(^{
+                        actualObject.shouldEqual = YES;
+                        expectedObject = [[[CustomObject alloc] init] autorelease];
+                    });
+
+                    describe(@"positive match", ^{
+                        it(@"should pass", ^{
+                            expect(actualObject).to(equal(expectedObject));
+                        });
+                    });
+
+                    describe(@"negative match", ^{
+                        it(@"should fail with a sensible failure message", ^{
+                            expectFailureWithMessage(@"Expected <CustomObject> to not equal <CustomObject>", ^{
+                                expect(actualObject).to_not(equal(expectedObject));
+                            });
+                        });
+                    });
+                });
+
+                describe(@"and the values are not equal", ^{
+                    beforeEach(^{
+                        actualObject.shouldEqual = NO;
+                        expectedObject = [[[CustomObject alloc] init] autorelease];
+                    });
+
+                    describe(@"positive match", ^{
+                        it(@"should fail with a sensible failure message", ^{
+                            expectFailureWithMessage(@"Expected <CustomObject> to equal <CustomObject>", ^{
+                                expect(actualObject).to(equal(expectedObject));
+                            });
+                        });
+                    });
+
+                    describe(@"negative match", ^{
+                        it(@"should pass", ^{
+                            expect(actualObject).to_not(equal(expectedObject));
+                        });
                     });
                 });
             });

--- a/Spec/Matchers/ExpectFailureWithMessage.m
+++ b/Spec/Matchers/ExpectFailureWithMessage.m
@@ -8,7 +8,8 @@ void expectFailureWithMessage(NSString *message, CDRSpecBlock block) {
     }
     @catch (CDRSpecFailure *x) {
         if (![message isEqualToString:x.reason]) {
-            fail([NSString stringWithFormat:@"Expected failure message: <%@> but received failure message <%@>", message, x.reason]);
+            NSString *reason = [NSString stringWithFormat:@"Expected failure message: <%@> but received failure message <%@>", message, x.reason];
+            [[CDRSpecFailure specFailureWithReason:reason fileName:x.fileName lineNumber:x.lineNumber] raise];
         }
         return;
     }


### PR DESCRIPTION
Calling `a should equal(b);` should call isEqual if both a and b are objects.
