### PR TITLE
Tweaked the templates to explicitly link against C++11

### DIFF
--- a/CodeSnippetsAndTemplates/Templates/Project Templates/Cedar/iOS Cedar Spec Suite.xctemplate/TemplateInfo.plist
+++ b/CodeSnippetsAndTemplates/Templates/Project Templates/Cedar/iOS Cedar Spec Suite.xctemplate/TemplateInfo.plist
@@ -128,6 +128,8 @@
 		<dict>
 			<key>SharedSettings</key>
 			<dict>
+				<key>CLANG_CXX_LIBRARY</key>
+				<string>libc++</string>
 				<key>OTHER_LDFLAGS</key>
 				<string>-ObjC -all_load -lstdc++</string>
 				<key>CODE_SIGN_IDENTITY[sdk=iphoneos*]</key>

--- a/CodeSnippetsAndTemplates/Templates/Project Templates/Cedar/iOS Cedar Testing Bundle.xctemplate/TemplateInfo.plist
+++ b/CodeSnippetsAndTemplates/Templates/Project Templates/Cedar/iOS Cedar Testing Bundle.xctemplate/TemplateInfo.plist
@@ -119,6 +119,8 @@
 				<string>$(SDKROOT)/Developer/Library/Frameworks $(DEVELOPER_LIBRARY_DIR)/Frameworks</string>
 				<key>OTHER_LDFLAGS</key>
 				<string>-ObjC -all_load -lstdc++</string>
+				<key>CLANG_CXX_LIBRARY</key>
+				<string>libc++</string>
 			</dict>
 		</dict>
 	</array>


### PR DESCRIPTION
I confess, I didn't test the OCUnit bunlde (but the change is identical for both targets).
