### PR TITLE
Fixed character escaping in the JUnit XML file.

### DIFF
--- a/Source/CDRJUnitXMLReporter.m
+++ b/Source/CDRJUnitXMLReporter.m
@@ -18,22 +18,15 @@
 
 #pragma mark - Private
 
-- (NSString *)escapeAttribute:(NSString *)s {
-    NSMutableString *escaped = [NSMutableString stringWithString:s];
-
-    [escaped setString:[escaped stringByReplacingOccurrencesOfString:@"\"" withString:@"&quot;"]];
-    [escaped setString:[escaped stringByReplacingOccurrencesOfString:@"'" withString:@"&apos;"]];
-
-    return escaped;
-}
-
 - (NSString *)escape:(NSString *)s {
     NSMutableString *escaped = [NSMutableString stringWithString:s];
 
     [escaped setString:[escaped stringByReplacingOccurrencesOfString:@"&" withString:@"&amp;"]];
     [escaped setString:[escaped stringByReplacingOccurrencesOfString:@">" withString:@"&gt;"]];
     [escaped setString:[escaped stringByReplacingOccurrencesOfString:@"<" withString:@"&lt;"]];
-
+    [escaped setString:[escaped stringByReplacingOccurrencesOfString:@"\"" withString:@"&quot;"]];
+    [escaped setString:[escaped stringByReplacingOccurrencesOfString:@"'" withString:@"&apos;"]];
+    
     return escaped;
 }
 
@@ -74,7 +67,7 @@
     [xml appendString:@"<testsuite>\n"];
 
     for (NSString *spec in successMessages_) {
-        [xml appendFormat:@"\t<testcase classname=\"Cedar\" name=\"%@\" />\n", [self escapeAttribute:spec]];
+        [xml appendFormat:@"\t<testcase classname=\"Cedar\" name=\"%@\" />\n", [self escape:spec]];
     }
 
     for (NSString *spec in failureMessages_) {
@@ -82,7 +75,7 @@
         NSString *name = [parts objectAtIndex:0];
         NSString *message = [parts objectAtIndex:1];
 
-        [xml appendFormat:@"\t<testcase classname=\"Cedar\" name=\"%@\">\n", [self escapeAttribute:name]];
+        [xml appendFormat:@"\t<testcase classname=\"Cedar\" name=\"%@\">\n", [self escape:name]];
         [xml appendFormat:@"\t\t<failure type=\"Failure\">%@</failure>\n", [self escape:message]];
         [xml appendString:@"\t</testcase>\n"];
     }

--- a/Spec/CDRJUnitXMLReporterSpec.mm
+++ b/Spec/CDRJUnitXMLReporterSpec.mm
@@ -89,13 +89,13 @@ describe(@"runDidComplete", ^{
         });
 
         it(@"should have its name escaped", ^{
-            CDRExample *example = [CDRExample exampleWithText:@"Special'Characters\"" andState:CDRExampleStatePassed];
+            CDRExample *example = [CDRExample exampleWithText:@"Special ' characters \" should < be & escaped > " andState:CDRExampleStatePassed];
 
             [reporter reportOnExample:example];
 
             [reporter runDidComplete];
 
-            expect([reporter.xml rangeOfString:@"name=\"Special&apos;Characters&quot;\""].location).to_not(equal((NSUInteger)NSNotFound));
+            expect([reporter.xml rangeOfString:@"name=\"Special &apos; characters &quot; should &lt; be &amp; escaped &gt; \""].location).to_not(equal((NSUInteger)NSNotFound));
         });
     });
 
@@ -116,23 +116,23 @@ describe(@"runDidComplete", ^{
         });
 
         it(@"should have its name escaped", ^{
-            CDRExample *example = [CDRExample exampleWithText:@"Special'Characters\"\n" andState:CDRExampleStateFailed];
+            CDRExample *example = [CDRExample exampleWithText:@"Special ' characters \" should < be & escaped > " andState:CDRExampleStateFailed];
 
             [reporter reportOnExample:example];
 
             [reporter runDidComplete];
 
-            expect([reporter.xml rangeOfString:@"name=\"Special&apos;Characters&quot;\""].location).to_not(equal((NSUInteger)NSNotFound));
+            expect([reporter.xml rangeOfString:@"name=\"Special &apos; characters &quot; should &lt; be &amp; escaped &gt; \""].location).to_not(equal((NSUInteger)NSNotFound));
         });
 
         it(@"should escape the failure reason", ^{
-            CDRExample *example1 = [CDRExample exampleWithText:@"Failing spec 1\nEscape<these>characters&" andState:CDRExampleStateFailed];
+            CDRExample *example1 = [CDRExample exampleWithText:@"Failing spec 1\n Special ' characters \" should < be & escaped > " andState:CDRExampleStateFailed];
 
             [reporter reportOnExample:example1];
 
             [reporter runDidComplete];
 
-            expect([reporter.xml rangeOfString:@"<failure type=\"Failure\">Escape&lt;these&gt;characters&amp;</failure>"].location).to_not(equal((NSUInteger)NSNotFound));
+            expect([reporter.xml rangeOfString:@"<failure type=\"Failure\"> Special &apos; characters &quot; should &lt; be &amp; escaped &gt; </failure>"].location).to_not(equal((NSUInteger)NSNotFound));
         });
     });
 


### PR DESCRIPTION
I've fixed an escaping issue with the JUnit XML spec reporter ('&' was not being escaped if it occurred in a spec name). This would cause failed Jenkins builds since the generated XML could not be parsed. Let me know if there are any issues, but hopefully it should be a small change!
