### PR TITLE
Resolved XCode 4.4 compilation failures caused by various format strings

### DIFF
--- a/Source/Doubles/CDRFake.mm
+++ b/Source/Doubles/CDRFake.mm
@@ -40,8 +40,9 @@
 
     if (![self.cedar_double_impl invoke_stubbed_method:invocation]) {
         if (require_explicit_stubs_) {
+            NSString * selectorString = NSStringFromSelector(invocation.selector);
             [[NSException exceptionWithName:NSInternalInconsistencyException
-                                     reason:[NSString stringWithFormat:@"Invocation of unstubbed method: %s", invocation.selector]
+                                     reason:[NSString stringWithFormat:@"Invocation of unstubbed method: %@", selectorString]
                                    userInfo:nil]
              raise];
         }

--- a/Source/Headers/Doubles/HaveReceived.h
+++ b/Source/Headers/Doubles/HaveReceived.h
@@ -82,7 +82,8 @@ namespace Cedar { namespace Doubles {
 
 #pragma mark Protected interface
     inline /*virtual*/ NSString * HaveReceived::failure_message_end() const {
-        NSMutableString *message = [NSMutableString stringWithFormat:@"have received message <%s>", this->selector()];
+        NSString * selectorString = NSStringFromSelector(this->selector());
+        NSMutableString *message = [NSMutableString stringWithFormat:@"have received message <%@>", selectorString];
         if (this->arguments().size()) {
             [message appendString:@", with arguments: <"];
             arguments_vector_t::const_iterator cit = this->arguments().begin();

--- a/Source/Headers/Doubles/InvocationMatcher.h
+++ b/Source/Headers/Doubles/InvocationMatcher.h
@@ -59,8 +59,9 @@ namespace Cedar { namespace Doubles {
         size_t expectedArgumentCount = this->arguments().size();
 
         if (actualArgumentCount != expectedArgumentCount) {
+            NSString * selectorString = NSStringFromSelector(this->selector());
             [[NSException exceptionWithName:NSInternalInconsistencyException
-                                     reason:[NSString stringWithFormat:@"Wrong number of expected parameters for <%s>; expected: %d, actual: %d", this->selector(), expectedArgumentCount, actualArgumentCount]
+                                     reason:[NSString stringWithFormat:@"Wrong number of expected parameters for <%@>; expected: %lu, actual: %lu", selectorString, (unsigned long)expectedArgumentCount, (unsigned long)actualArgumentCount]
                                    userInfo:nil]
              raise];
         }
@@ -69,11 +70,12 @@ namespace Cedar { namespace Doubles {
         for (arguments_vector_t::const_iterator cit = this->arguments().begin(); cit != this->arguments().end(); ++cit, ++index) {
             const char * actual_argument_encoding = [methodSignature getArgumentTypeAtIndex:index];
             if (!(*cit)->matches_encoding(actual_argument_encoding)) {
-                NSString *reason = [NSString stringWithFormat:@"Attempt to compare expected argument <%@> with actual argument type %s; argument #%d for <%s>",
+                NSString * selectorString = NSStringFromSelector(this->selector());
+                NSString *reason = [NSString stringWithFormat:@"Attempt to compare expected argument <%@> with actual argument type %s; argument #%lu for <%@>",
                                     (*cit)->value_string(),
                                     actual_argument_encoding,
-                                    index - OBJC_DEFAULT_ARGUMENT_COUNT + 1,
-                                    this->selector()];
+                                    (unsigned long)(index - OBJC_DEFAULT_ARGUMENT_COUNT + 1),
+                                    selectorString];
                 [[NSException exceptionWithName:NSInternalInconsistencyException reason:reason userInfo:nil] raise];
             }
         }

--- a/Source/Headers/Doubles/StubbedMethod.h
+++ b/Source/Headers/Doubles/StubbedMethod.h
@@ -99,8 +99,9 @@ namespace Cedar { namespace Doubles {
         if (has_return_value()) {
             const char * const methodReturnType = [[instance methodSignatureForSelector:selector()] methodReturnType];
             if (!return_value().matches_encoding(methodReturnType)) {
+                NSString * selectorString = NSStringFromSelector(selector());
                 [[NSException exceptionWithName:NSInternalInconsistencyException
-                                         reason:[NSString stringWithFormat:@"Invalid return value type (%s) for %s", return_value().value_encoding(), selector()]
+                                         reason:[NSString stringWithFormat:@"Invalid return value type (%s) for %@", return_value().value_encoding(), selectorString]
                                        userInfo:nil] raise];
 
             }

--- a/Source/Headers/Matchers/Base/Base.h
+++ b/Source/Headers/Matchers/Base/Base.h
@@ -41,11 +41,15 @@ namespace Cedar { namespace Matchers {
 
     template<typename MessageBuilder_> template<typename U>
     NSString * Base<MessageBuilder_>::failure_message_for(const U & value) const {
-        return [NSString stringWithFormat:@"Expected <%@> to %@", MessageBuilder_::string_for_actual_value(value), this->failure_message_end()];
+        NSString * failureMessageEnd = this->failure_message_end();
+        NSString * actualValueString = MessageBuilder_::string_for_actual_value(value);
+        return [NSString stringWithFormat:@"Expected <%@> to %@", actualValueString, failureMessageEnd];
     }
 
     template<typename MessageBuilder_> template<typename U>
     NSString * Base<MessageBuilder_>::negative_failure_message_for(const U & value) const {
-        return [NSString stringWithFormat:@"Expected <%@> to not %@", MessageBuilder_::string_for_actual_value(value), this->failure_message_end()];
+        NSString * failureMessageEnd = this->failure_message_end();
+        NSString * actualValueString = MessageBuilder_::string_for_actual_value(value);
+        return [NSString stringWithFormat:@"Expected <%@> to not %@", actualValueString, failureMessageEnd];
     }
 }}

--- a/Source/Headers/Matchers/Base/BeCloseTo.h
+++ b/Source/Headers/Matchers/Base/BeCloseTo.h
@@ -52,7 +52,9 @@ namespace Cedar { namespace Matchers {
 
     template<typename T>
     /*virtual*/ NSString * BeCloseTo<T>::failure_message_end() const {
-        return [NSString stringWithFormat:@"be close to <%@> (within %@)", Stringifiers::string_for(expectedValue_), Stringifiers::string_for(threshold_)];
+        NSString * expectedValueString = Stringifiers::string_for(expectedValue_);
+        NSString * thresholdString = Stringifiers::string_for(threshold_);
+        return [NSString stringWithFormat:@"be close to <%@> (within %@)", expectedValueString, thresholdString];
     }
 
     template<typename T> template<typename U, typename V>

--- a/Source/Headers/Matchers/Base/BeGTE.h
+++ b/Source/Headers/Matchers/Base/BeGTE.h
@@ -44,7 +44,8 @@ namespace Cedar { namespace Matchers {
 
     template<typename T>
     /*virtual*/ NSString * BeGTE<T>::failure_message_end() const {
-        return [NSString stringWithFormat:@"be greater than or equal to <%@>", Stringifiers::string_for(expectedValue_)];
+        NSString * expectedValueString = Stringifiers::string_for(expectedValue_);
+        return [NSString stringWithFormat:@"be greater than or equal to <%@>", expectedValueString];
     }
 
     template<typename T> template<typename U>

--- a/Source/Headers/Matchers/Base/BeGreaterThan.h
+++ b/Source/Headers/Matchers/Base/BeGreaterThan.h
@@ -39,7 +39,8 @@ namespace Cedar { namespace Matchers {
 
     template<typename T>
     /*virtual*/ NSString * BeGreaterThan<T>::failure_message_end() const {
-        return [NSString stringWithFormat:@"be greater than <%@>", Stringifiers::string_for(expectedValue_)];
+        NSString * expectedValueString = Stringifiers::string_for(expectedValue_);
+        return [NSString stringWithFormat:@"be greater than <%@>", expectedValueString];
     }
 
     template<typename T> template<typename U>

--- a/Source/Headers/Matchers/Base/BeInstanceOf.h
+++ b/Source/Headers/Matchers/Base/BeInstanceOf.h
@@ -4,7 +4,8 @@ namespace Cedar { namespace Matchers {
     struct BeInstanceOfMessageBuilder {
         template<typename U>
         static NSString * string_for_actual_value(const U & value) {
-            return [NSString stringWithFormat:@"%@ (%@)", value, [value class]];
+            id idValue = value;
+            return [NSString stringWithFormat:@"%@ (%@)", idValue, NSStringFromClass([idValue class])];
         }
     };
 

--- a/Source/Headers/Matchers/Base/BeLTE.h
+++ b/Source/Headers/Matchers/Base/BeLTE.h
@@ -44,7 +44,8 @@ namespace Cedar { namespace Matchers {
 
     template<typename T>
     /*virtual*/ NSString * BeLTE<T>::failure_message_end() const {
-        return [NSString stringWithFormat:@"be less than or equal to <%@>", Stringifiers::string_for(expectedValue_)];
+        NSString * expectedValueString = Stringifiers::string_for(expectedValue_);
+        return [NSString stringWithFormat:@"be less than or equal to <%@>", expectedValueString];
     }
 
     template<typename T> template<typename U>

--- a/Source/Headers/Matchers/Base/BeLessThan.h
+++ b/Source/Headers/Matchers/Base/BeLessThan.h
@@ -39,7 +39,8 @@ namespace Cedar { namespace Matchers {
 
     template<typename T>
     /*virtual*/ NSString * BeLessThan<T>::failure_message_end() const {
-        return [NSString stringWithFormat:@"be less than <%@>", Stringifiers::string_for(expectedValue_)];
+        NSString * expectedValueString = Stringifiers::string_for(expectedValue_);
+        return [NSString stringWithFormat:@"be less than <%@>", expectedValueString];
     }
 
     template<typename T> template<typename U>

--- a/Source/Headers/Matchers/Base/Equal.h
+++ b/Source/Headers/Matchers/Base/Equal.h
@@ -39,7 +39,8 @@ namespace Cedar { namespace Matchers {
 
     template<typename T>
     /*virtual*/ NSString * Equal<T>::failure_message_end() const {
-        return [NSString stringWithFormat:@"equal <%@>", Stringifiers::string_for(expectedValue_)];
+        NSString * expectedValueString = Stringifiers::string_for(expectedValue_);
+        return [NSString stringWithFormat:@"equal <%@>", expectedValueString];
     }
 
     template<typename T> template<typename U>

--- a/Source/Headers/Matchers/Container/Contain.h
+++ b/Source/Headers/Matchers/Container/Contain.h
@@ -37,7 +37,8 @@ namespace Cedar { namespace Matchers {
 
     template<typename T>
     inline /*virtual*/ NSString * Contain<T>::failure_message_end() const {
-        return [NSString stringWithFormat:@"contain <%@>", Stringifiers::string_for(element_)];
+        NSString * elementString = Stringifiers::string_for(element_);
+        return [NSString stringWithFormat:@"contain <%@>", elementString];
     }
 
 #pragma mark Generic

--- a/Source/Headers/Matchers/Stringifiers/StringifiersContainer.h
+++ b/Source/Headers/Matchers/Stringifiers/StringifiersContainer.h
@@ -12,7 +12,9 @@ namespace Cedar { namespace Matchers { namespace Stringifiers {
                 if (!first) {
                     [result appendString:@","];
                 }
-                [result appendString:[NSString stringWithFormat:@"\n    %@", string_for(*it)]];
+                
+                NSString * string = string_for(*it);
+                [result appendString:[NSString stringWithFormat:@"\n    %@", string]];
             }
             return result;
         }
@@ -20,7 +22,8 @@ namespace Cedar { namespace Matchers { namespace Stringifiers {
 
     template<typename T>
     NSString * string_for(const typename std::vector<T> & container) {
-        return [NSString stringWithFormat:@"(%@\n)", comma_and_newline_delimited_list(container)];
+        NSString * delimitedList = comma_and_newline_delimited_list(container);
+        return [NSString stringWithFormat:@"(%@\n)", delimitedList];
     }
 
     template<typename T, typename U>
@@ -28,7 +31,9 @@ namespace Cedar { namespace Matchers { namespace Stringifiers {
         NSMutableString *result = [NSMutableString stringWithString:@"{"];
 
         for (typename std::map<T, U>::const_iterator it = container.begin(); it != container.end(); ++it) {
-            [result appendString:[NSString stringWithFormat:@"\n    %@ = %@;", string_for(it->first), string_for(it->second)]];
+            NSString * keyString = string_for(it->first);
+            NSString * valueString = string_for(it->second);
+            [result appendString:[NSString stringWithFormat:@"\n    %@ = %@;", keyString, valueString]];
         }
         [result appendString:@"\n}"];
         return result;
@@ -36,6 +41,7 @@ namespace Cedar { namespace Matchers { namespace Stringifiers {
 
     template<typename T>
     NSString * string_for(const typename std::set<T> & container) {
-        return [NSString stringWithFormat:@"{(%@\n)}", comma_and_newline_delimited_list(container)];
+        NSString * delimitedList = comma_and_newline_delimited_list(container);
+        return [NSString stringWithFormat:@"{(%@\n)}", delimitedList];
     }
 }}}

--- a/Spec/Doubles/HaveReceivedSpec.mm
+++ b/Spec/Doubles/HaveReceivedSpec.mm
@@ -36,7 +36,8 @@ describe(@"have_received matcher", ^{
 
         context(@"with a parameter expectation", ^{
             it(@"should raise an exception due to an invalid expectation", ^{
-                NSString *reason = [NSString stringWithFormat:@"Wrong number of expected parameters for <%s>; expected: 1, actual: 0", method];
+                NSString *methodString = NSStringFromSelector(method);
+                NSString *reason = [NSString stringWithFormat:@"Wrong number of expected parameters for <%@>; expected: 1, actual: 0", methodString];
                 ^{ expect(incrementer).to(have_received(method).with(anything)); } should raise_exception.with_reason(reason);
             });
         });
@@ -93,7 +94,8 @@ describe(@"have_received matcher", ^{
 
         context(@"with too many parameter expectations", ^{
             it(@"should raise an exception due to an invalid expectation", ^{
-                NSString *reason = [NSString stringWithFormat:@"Wrong number of expected parameters for <%s>; expected: 2, actual: 1", method];
+                NSString *methodName = NSStringFromSelector(method);
+                NSString *reason = [NSString stringWithFormat:@"Wrong number of expected parameters for <%@>; expected: 2, actual: 1", methodName];
                 ^{ expect(incrementer).to(have_received(method).with(anything).and_with(anything)); } should raise_exception.with_reason(reason);
             });
         });
@@ -178,11 +180,11 @@ describe(@"have_received matcher", ^{
 
             describe(@"positive match", ^{
                 it(@"should fail with a sensible failure message", ^{
-                    expectFailureWithMessage([NSString stringWithFormat:@"Expected <%@> to have received message <%@>, with arguments: <%d>", incrementer, NSStringFromSelector(method), expectedParameter], ^{
+                    expectFailureWithMessage([NSString stringWithFormat:@"Expected <%@> to have received message <%@>, with arguments: <%ld>", incrementer, NSStringFromSelector(method), expectedParameter], ^{
                         expect(incrementer).to(have_received(method).with(expectedParameter));
                     });
 
-                    expectFailureWithMessage([NSString stringWithFormat:@"Expected <%@> to have received message <%@>, with arguments: <%d>", incrementer, NSStringFromSelector(method), expectedParameter], ^{
+                    expectFailureWithMessage([NSString stringWithFormat:@"Expected <%@> to have received message <%@>, with arguments: <%ld>", incrementer, NSStringFromSelector(method), expectedParameter], ^{
                         expect(incrementer).to(have_received("incrementBy:").with(expectedParameter));
                     });
                 });
@@ -305,7 +307,8 @@ describe(@"have_received matcher", ^{
 
         context(@"with too few parameter expectations", ^{
             it(@"should raise an exception due to an invalid expectation", ^{
-                NSString *reason = [NSString stringWithFormat:@"Wrong number of expected parameters for <%s>; expected: 1, actual: 2", method];
+                NSString *methodName = NSStringFromSelector(method);
+                NSString *reason = [NSString stringWithFormat:@"Wrong number of expected parameters for <%@>; expected: 1, actual: 2", methodName];
                 ^{ expect(incrementer).to(have_received(method).with(anything)); } should raise_exception.with_reason(reason);
             });
         });
@@ -328,11 +331,11 @@ describe(@"have_received matcher", ^{
 
                 describe(@"negative match", ^{
                     it(@"should fail with a sensible failure message", ^{
-                        expectFailureWithMessage([NSString stringWithFormat:@"Expected <%@> to not have received message <%@>, with arguments: <%d, %@>", incrementer, NSStringFromSelector(method), expectedFirstParameter, expectedSecondParameter], ^{
+                        expectFailureWithMessage([NSString stringWithFormat:@"Expected <%@> to not have received message <%@>, with arguments: <%llu, %@>", incrementer, NSStringFromSelector(method), expectedFirstParameter, expectedSecondParameter], ^{
                             expect(incrementer).to_not(have_received(method).with(expectedFirstParameter).and_with(expectedSecondParameter));
                         });
 
-                        expectFailureWithMessage([NSString stringWithFormat:@"Expected <%@> to not have received message <%@>, with arguments: <%d, %@>", incrementer, NSStringFromSelector(method), expectedFirstParameter, expectedSecondParameter], ^{
+                        expectFailureWithMessage([NSString stringWithFormat:@"Expected <%@> to not have received message <%@>, with arguments: <%llu, %@>", incrementer, NSStringFromSelector(method), expectedFirstParameter, expectedSecondParameter], ^{
                             expect(incrementer).to_not(have_received("incrementByABit:andABitMore:").with(expectedFirstParameter).and_with(expectedSecondParameter));
                         });
                     });
@@ -345,11 +348,11 @@ describe(@"have_received matcher", ^{
 
                 describe(@"positive match", ^{
                     it(@"should fail with a sensible failure message", ^{
-                        expectFailureWithMessage([NSString stringWithFormat:@"Expected <%@> to have received message <%@>, with arguments: <%d, %@>", incrementer, NSStringFromSelector(method), expectedFirstParameter, expectedSecondParameter], ^{
+                        expectFailureWithMessage([NSString stringWithFormat:@"Expected <%@> to have received message <%@>, with arguments: <%llu, %@>", incrementer, NSStringFromSelector(method), expectedFirstParameter, expectedSecondParameter], ^{
                             expect(incrementer).to(have_received(method).with(expectedFirstParameter).and_with(expectedSecondParameter));
                         });
 
-                        expectFailureWithMessage([NSString stringWithFormat:@"Expected <%@> to have received message <%@>, with arguments: <%d, %@>", incrementer, NSStringFromSelector(method), expectedFirstParameter, expectedSecondParameter], ^{
+                        expectFailureWithMessage([NSString stringWithFormat:@"Expected <%@> to have received message <%@>, with arguments: <%llu, %@>", incrementer, NSStringFromSelector(method), expectedFirstParameter, expectedSecondParameter], ^{
                             expect(incrementer).to(have_received("incrementByABit:andABitMore:").with(expectedFirstParameter).and_with(expectedSecondParameter));
                         });
                     });


### PR DESCRIPTION
Cedar master fails to compile on XCode 4.4 due to a bunch of string formatting failures. It seems that the latest version of XCode is much more strict about failing when improper or ambiguous format strings are discovered.

This pull request resolves these issues.
