### PR TITLE
Tests are randomly permuted

### DIFF
--- a/Source/CDRDefaultReporter.m
+++ b/Source/CDRDefaultReporter.m
@@ -35,10 +35,11 @@
 }
 
 #pragma mark Public interface
-- (void)runWillStartWithGroups:(NSArray *)groups {
+- (void)runWillStartWithGroups:(NSArray *)groups andRandomSeed:(unsigned int)seed {
     rootGroups_ = [groups retain];
     [self startObservingExamples:rootGroups_];
     startTime_ = [[NSDate alloc] init];
+    printf("Running With Random Seed: %i\n\n", seed);
 }
 
 - (void)runDidComplete {

--- a/Source/Headers/CDRExampleReporter.h
+++ b/Source/Headers/CDRExampleReporter.h
@@ -2,7 +2,7 @@
 
 @protocol CDRExampleReporter <NSObject>
 
-- (void)runWillStartWithGroups:(NSArray *)groups;
+- (void)runWillStartWithGroups:(NSArray *)groups andRandomSeed:(unsigned int)seed;
 - (void)runDidComplete;
 - (int)result;
 

--- a/Source/iPhone/CDRExampleReporterViewController.m
+++ b/Source/iPhone/CDRExampleReporterViewController.m
@@ -37,7 +37,7 @@
 }
 
 #pragma mark CDRExampleReporter
-- (void)runWillStartWithGroups:(NSArray *)groups {
+- (void)runWillStartWithGroups:(NSArray *)groups andRandomSeed:(unsigned int)seed {
     // The specs run on a background thread, so callbacks from the runner will
     // arrive on that thread.  We need to push the event to the main thread in
     // order to update the UI.


### PR DESCRIPTION
I've been in a few situations where this would have been valuable.

Tests are now randomly permuted every time the tests run.  The reporter prints out the seed used to permute the tests.

The seed can be set using the CEDAR_RANDOM_SEED environment variable, doing so reproduces the permutation order.

Random tests orders are important for identifying test pollution.  Being able to reproduce the permuted order is important for debugging said test pollution!
