### PR TITLE
Wraps fake simulator setup in an autorelease pool

### DIFF
--- a/Source/iPhone/HeadlessSimulatorWorkaround.m
+++ b/Source/iPhone/HeadlessSimulatorWorkaround.m
@@ -3,6 +3,7 @@
 
 void setUpFakeWorkspaceIfRequired() {
 #if TARGET_IPHONE_SIMULATOR
+    NSAutoreleasePool *pool = [[NSAutoreleasePool alloc] init];
     NSString *systemVersion = [[UIDevice currentDevice] systemVersion];
     NSInteger majorVersion = [[[systemVersion componentsSeparatedByString:@"."] objectAtIndex:0] integerValue];
     if (majorVersion >= 6 && CFMessagePortCreateRemote(NULL, (CFStringRef)@"PurpleWorkspacePort") == NULL) {
@@ -10,5 +11,6 @@ void setUpFakeWorkspaceIfRequired() {
         CFMessagePortCreateLocal(NULL, (CFStringRef)@"PurpleWorkspacePort", NULL, NULL, NULL);
         class_replaceMethod([UIWindow class], @selector(_createContext), imp_implementationWithBlock(^{}), "v@:");
     }
+    [pool drain];
 #endif
 }


### PR DESCRIPTION
Fixes possible leak under iOS versions prior to 6

objc[84078]: Object 0x6d27670 of class __NSCFString autoreleased with no pool in place - just leaking - break on objc_autoreleaseNoPool() to debug
objc[84078]: Object 0x6d273f0 of class __NSArrayM autoreleased with no pool in place - just leaking - break on objc_autoreleaseNoPool() to debug
