### PR TITLE
Enable running against iOS SDK 6.1 in CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,6 @@
 language: objective-c
 
 env:
-  - CEDAR_SDK_VERSION="5.1"
   - CEDAR_SDK_VERSION="6.0"
   - CEDAR_SDK_VERSION="6.1"
 


### PR DESCRIPTION
Travis now supports running against iOS SDK 6.1. This commit makes Cedar run against it in a new CI build.
