### PR TITLE
Fixing leaky Cedar Doubles

### DIFF
--- a/Source/Doubles/CedarDoubleImpl.mm
+++ b/Source/Doubles/CedarDoubleImpl.mm
@@ -85,7 +85,6 @@
 }
 
 - (void)record_method_invocation:(NSInvocation *)invocation {
-    [invocation retainArguments];
     [self.sent_messages addObject:invocation];
 }
 

--- a/Spec/Doubles/CedarDoubleSharedExamples.mm
+++ b/Spec/Doubles/CedarDoubleSharedExamples.mm
@@ -40,6 +40,23 @@ sharedExamplesFor(@"a Cedar double", ^(NSDictionary *sharedContext) {
         });
     });
 
+    context(@"when recording an invocation", ^{
+        it(@"should not retain the double", ^{
+            myDouble stub_method("value");
+
+            int doubleRetainCount = myDouble.retainCount;
+
+            @autoreleasepool {
+                [myDouble value];
+                // spies are allowed to increment the retain count of the double by 1
+                // but should hand the retain over to the autorelease pool
+                myDouble.retainCount should be_less_than_or_equal_to(doubleRetainCount + 1);
+            }
+
+            myDouble.retainCount should equal(doubleRetainCount);
+        });
+    });
+
     describe(@"#stub_method", ^{
         context(@"with a non-double", ^{
             it(@"should raise an exception", ^{


### PR DESCRIPTION
Cedar doubles were leaking whenever an invocation was registered as the invocation was instructed to retain all arguments (which, incidentally, retains the target -- in this case, the double).
