### PR TITLE
default rake task ensures iOS 5.1 compatibility

### DIFF
--- a/Cedar.xcodeproj/project.pbxproj
+++ b/Cedar.xcodeproj/project.pbxproj
@@ -136,6 +136,8 @@
 		AE36AC6315B4BBFC00EB6C51 /* NoOpKeyValueObserver.m in Sources */ = {isa = PBXBuildFile; fileRef = AE36AC6015B4BB3B00EB6C51 /* NoOpKeyValueObserver.m */; };
 		AE36AC6515B5CA6E00EB6C51 /* CedarDouble.mm in Sources */ = {isa = PBXBuildFile; fileRef = AE36AC6415B5CA6E00EB6C51 /* CedarDouble.mm */; };
 		AE36AC6615B5CA6E00EB6C51 /* CedarDouble.mm in Sources */ = {isa = PBXBuildFile; fileRef = AE36AC6415B5CA6E00EB6C51 /* CedarDouble.mm */; };
+		AE5218D3175979CA00A656BC /* ObjectWithWeakDelegate.m in Sources */ = {isa = PBXBuildFile; fileRef = AE5218D2175979CA00A656BC /* ObjectWithWeakDelegate.m */; settings = {COMPILER_FLAGS = "-fobjc-arc"; }; };
+		AE5218D5175979D900A656BC /* WeakReferenceCompatibilitySpec.mm in Sources */ = {isa = PBXBuildFile; fileRef = AE5218D4175979D900A656BC /* WeakReferenceCompatibilitySpec.mm */; };
 		AE597B4115B0638B00EEF305 /* InvocationMatcher.h in Headers */ = {isa = PBXBuildFile; fileRef = AE597B4015B0638B00EEF305 /* InvocationMatcher.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		AE597B4215B0638B00EEF305 /* InvocationMatcher.h in Headers */ = {isa = PBXBuildFile; fileRef = AE597B4015B0638B00EEF305 /* InvocationMatcher.h */; };
 		AE6F3F341458D7C100C98F1E /* BeGreaterThanSpec.mm in Sources */ = {isa = PBXBuildFile; fileRef = AE6F3F331458D7C100C98F1E /* BeGreaterThanSpec.mm */; };
@@ -514,6 +516,9 @@
 		AE36AC5F15B4BB2D00EB6C51 /* NoOpKeyValueObserver.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = NoOpKeyValueObserver.h; sourceTree = "<group>"; };
 		AE36AC6015B4BB3B00EB6C51 /* NoOpKeyValueObserver.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = NoOpKeyValueObserver.m; sourceTree = "<group>"; };
 		AE36AC6415B5CA6E00EB6C51 /* CedarDouble.mm */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.objcpp; path = CedarDouble.mm; sourceTree = "<group>"; };
+		AE5218D1175979CA00A656BC /* ObjectWithWeakDelegate.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = ObjectWithWeakDelegate.h; sourceTree = "<group>"; };
+		AE5218D2175979CA00A656BC /* ObjectWithWeakDelegate.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = ObjectWithWeakDelegate.m; sourceTree = "<group>"; };
+		AE5218D4175979D900A656BC /* WeakReferenceCompatibilitySpec.mm */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.objcpp; path = WeakReferenceCompatibilitySpec.mm; sourceTree = "<group>"; };
 		AE597B4015B0638B00EEF305 /* InvocationMatcher.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = InvocationMatcher.h; sourceTree = "<group>"; };
 		AE6F3F331458D7C100C98F1E /* BeGreaterThanSpec.mm */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.objcpp; path = BeGreaterThanSpec.mm; sourceTree = "<group>"; };
 		AE74902E15B45E80008EA127 /* CDRProtocolFake.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = CDRProtocolFake.h; sourceTree = "<group>"; };
@@ -1105,10 +1110,11 @@
 		AEEE1FEB11DC27B800029872 /* iPhone */ = {
 			isa = PBXGroup;
 			children = (
-				AE7DD11117296CB20058EB3B /* CedarApplicationDelegateSpec.mm */,
 				AEEE1FEC11DC27B800029872 /* CDRExampleStateMapSpec.mm */,
-				AEEE1FEE11DC27B800029872 /* SlowSpec.m */,
+				AE7DD11117296CB20058EB3B /* CedarApplicationDelegateSpec.mm */,
 				AEEE1FED11DC27B800029872 /* main.m */,
+				AEEE1FEE11DC27B800029872 /* SlowSpec.m */,
+				AE5218D4175979D900A656BC /* WeakReferenceCompatibilitySpec.mm */,
 			);
 			path = iPhone;
 			sourceTree = "<group>";
@@ -1204,6 +1210,8 @@
 			children = (
 				E32861301604F287001FA77E /* FibonacciCalculator.h */,
 				E32861311604F287001FA77E /* FibonacciCalculator.m */,
+				AE5218D1175979CA00A656BC /* ObjectWithWeakDelegate.h */,
+				AE5218D2175979CA00A656BC /* ObjectWithWeakDelegate.m */,
 			);
 			path = Support;
 			sourceTree = "<group>";
@@ -1790,6 +1798,8 @@
 				E32861331604F287001FA77E /* FibonacciCalculator.m in Sources */,
 				96B591911630F5B10068EA5E /* ObjCHeadersSpec.mm in Sources */,
 				AE7DD11217296CB20058EB3B /* CedarApplicationDelegateSpec.mm in Sources */,
+				AE5218D3175979CA00A656BC /* ObjectWithWeakDelegate.m in Sources */,
+				AE5218D5175979D900A656BC /* WeakReferenceCompatibilitySpec.mm in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/Rakefile
+++ b/Rakefile
@@ -16,14 +16,15 @@ XCODE_TEMPLATES_DIR = "#{ENV['HOME']}/Library/Developer/Xcode/Templates"
 XCODE_SNIPPETS_DIR = "#{ENV['HOME']}/Library/Developer/Xcode/UserData/CodeSnippets"
 
 SDK_VERSION = ENV["CEDAR_SDK_VERSION"] || "6.1"
+UISPEC_VERSIONS = [SDK_VERSION, "5.1"]
 PROJECT_ROOT = File.dirname(__FILE__)
 BUILD_DIR = File.join(PROJECT_ROOT, "build")
 TEMPLATES_DIR = File.join(PROJECT_ROOT, "CodeSnippetsAndTemplates", "Templates")
 SNIPPETS_DIR = File.join(PROJECT_ROOT, "CodeSnippetsAndTemplates", "CodeSnippets")
 DIST_STAGING_DIR = "#{BUILD_DIR}/dist"
 
-def sdk_dir
-  "#{xcode_developer_dir}/Platforms/iPhoneSimulator.platform/Developer/SDKs/iPhoneSimulator#{SDK_VERSION}.sdk"
+def sdk_dir(version = SDK_VERSION)
+  "#{xcode_developer_dir}/Platforms/iPhoneSimulator.platform/Developer/SDKs/iPhoneSimulator#{version}.sdk"
 end
 
 # Xcode 4.3 stores its /Developer inside /Applications/Xcode.app, Xcode 4.2 stored it in /Developer
@@ -131,16 +132,19 @@ require 'tmpdir'
 
 desc "Run UI specs"
 task :uispecs => :build_uispecs do
-  env_vars = {
-    "DYLD_ROOT_PATH" => sdk_dir,
-    "IPHONE_SIMULATOR_ROOT" => sdk_dir,
-    "CFFIXED_USER_HOME" => Dir.tmpdir,
-    "CEDAR_HEADLESS_SPECS" => "1",
-    "CEDAR_REPORTER_CLASS" => "CDRColorizedReporter",
-  }
+  UISPEC_VERSIONS.each do |version|
+    sdk_path = sdk_dir(version)
+    env_vars = {
+      "DYLD_ROOT_PATH" => sdk_path,
+      "IPHONE_SIMULATOR_ROOT" => sdk_path,
+      "CFFIXED_USER_HOME" => Dir.tmpdir,
+      "CEDAR_HEADLESS_SPECS" => "1",
+      "CEDAR_REPORTER_CLASS" => "CDRColorizedReporter",
+    }
 
-  with_env_vars(env_vars) do
-    system_or_exit "#{File.join(build_dir("-iphonesimulator"), "#{UI_SPECS_TARGET_NAME}.app", UI_SPECS_TARGET_NAME)} -RegisterForSystemEvents";
+    with_env_vars(env_vars) do
+      system_or_exit "#{File.join(build_dir("-iphonesimulator"), "#{UI_SPECS_TARGET_NAME}.app", UI_SPECS_TARGET_NAME)} -RegisterForSystemEvents";
+    end
   end
 end
 

--- a/Spec/Support/ObjectWithWeakDelegate.h
+++ b/Spec/Support/ObjectWithWeakDelegate.h
@@ -1,0 +1,15 @@
+#import <Foundation/Foundation.h>
+
+@protocol ExampleDelegate <NSObject>
+
+- (void)someMessage;
+
+@end
+
+@interface ObjectWithWeakDelegate : NSObject
+
+@property (weak, nonatomic) id<ExampleDelegate> delegate;
+
+- (void)tellTheDelegate;
+
+@end

--- a/Spec/Support/ObjectWithWeakDelegate.m
+++ b/Spec/Support/ObjectWithWeakDelegate.m
@@ -1,0 +1,9 @@
+#import "ObjectWithWeakDelegate.h"
+
+@implementation ObjectWithWeakDelegate
+
+- (void)tellTheDelegate {
+    [self.delegate someMessage];
+}
+
+@end

--- a/Spec/iPhone/WeakReferenceCompatibilitySpec.mm
+++ b/Spec/iPhone/WeakReferenceCompatibilitySpec.mm
@@ -1,0 +1,39 @@
+#import "SpecHelper.h"
+#import "ObjectWithWeakDelegate.h"
+
+using namespace Cedar::Matchers;
+using namespace Cedar::Doubles;
+
+SPEC_BEGIN(WeakReferenceCompatibilitySpec)
+
+// This spec exists as a regression test to ensure that Cedar Doubles continue
+// to work with the iOS 5 runtime.
+//
+// For more info please see http://openradar.appspot.com/11117786
+// or http://stackoverflow.com/questions/8675054/why-is-my-objects-weak-delegate-property-nil-in-my-unit-tests
+
+describe(@"An object with a weak reference to a Cedar Double", ^{
+    __block ObjectWithWeakDelegate *object;
+
+    beforeEach(^{
+        id<ExampleDelegate> fakeDelegate = nice_fake_for(@protocol(ExampleDelegate));
+        object = [[[ObjectWithWeakDelegate alloc] init] autorelease];
+        object.delegate = fakeDelegate;
+    });
+
+    it(@"should have the Double as a delegate", ^{
+        object.delegate should_not be_nil;
+    });
+
+    describe(@"when sending a message", ^{
+        beforeEach(^{
+            [object tellTheDelegate];
+        });
+
+        it(@"should result in the double having received the message", ^{
+            object.delegate should have_received(@selector(someMessage));
+        });
+    });
+});
+
+SPEC_END


### PR DESCRIPTION
This is a defensive measure against an iOS 5 runtime bug.
See http://openradar.appspot.com/11117786 or http://stackoverflow.com/questions/8675054/why-is-my-objects-weak-delegate-property-nil-in-my-unit-tests
