### PR TITLE
Changes rake install to work with symlinks

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -229,6 +229,6 @@ end
 desc "Build frameworks and install templates and code snippets"
 task :install => [ :clean, :uninstall, "dist:prepare" ] do
   puts "\nInstalling templates...\n"
-  system_or_exit %{ditto "#{DIST_STAGING_DIR}/Library" ~/Library}
+  system_or_exit %{rsync -vcrlK "#{DIST_STAGING_DIR}/Library/" ~/Library}
 end
 


### PR DESCRIPTION
This is helpful for users who have symlinked their Xcode/AppCode
preferences to a location which is under source control.
It also preserves symlinks within the installed Cedar frameworks.
