### PR TITLE
Re-enable testing against older iOS SDKs in CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,8 @@
 language: objective-c
 
 env:
+  - CEDAR_SDK_VERSION="5.0"
+  - CEDAR_SDK_VERSION="5.1"
   - CEDAR_SDK_VERSION="6.0"
   - CEDAR_SDK_VERSION="6.1"
 


### PR DESCRIPTION
The more SDKs we work against the merrier! Looks like Travis has re-added
support for testing against the 5.0 and 5.1 iOS SDKs since we had to originally
take them out in this commit: 8aef6e7ccfbce87b6cf170260ce08e1faf3d7f83
