### PR TITLE
More specific protocol fake handling of optional protocol methods

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -190,6 +190,14 @@ Method stubbing:
     fake stub_method("selector").with(anything);
 
 
+Protocol fakes:
+
+    id<CedarDouble> anotherFake = fake_for(someProtocol);
+    id<CedarDouble> anotherNiceFake = nice_fake_for(someProtocol);
+
+A nice fake will respond to all protocol methods and record their invocations.
+A non-nice fake will not respond to optional protocol methods, and requires stubs to be set up before messages are received.
+
 ## Shared example groups
 
 Cedar supports shared example groups; you can declare them in one of two ways:

--- a/Source/Doubles/CDRClassFake.mm
+++ b/Source/Doubles/CDRClassFake.mm
@@ -20,6 +20,6 @@
 
 @end
 
-id CDR_fake_for(Class klass, bool require_explicit_stubs /*= true*/) {
+id CDR_fake_for(Class klass, BOOL require_explicit_stubs /*= YES */) {
     return [[[CDRClassFake alloc] initWithClass:klass requireExplicitStubs:require_explicit_stubs] autorelease];
 }

--- a/Source/Doubles/CDRFake.mm
+++ b/Source/Doubles/CDRFake.mm
@@ -3,9 +3,7 @@
 #import "StubbedMethod.h"
 #import "CedarDoubleImpl.h"
 
-@interface CDRFake () {
-    bool require_explicit_stubs_;
-}
+@interface CDRFake ()
 
 @property (nonatomic, retain) CedarDoubleImpl *cedar_double_impl;
 
@@ -13,11 +11,11 @@
 
 @implementation CDRFake
 
-@synthesize klass = klass_, cedar_double_impl = cedar_double_impl_;
+@synthesize klass = klass_, cedar_double_impl = cedar_double_impl_, requiresExplicitStubs = requiresExplicitStubs_;
 
-- (id)initWithClass:(Class)klass requireExplicitStubs:(bool)requireExplicitStubs {
+- (id)initWithClass:(Class)klass requireExplicitStubs:(BOOL)requireExplicitStubs {
     if (self = [super init]) {
-        require_explicit_stubs_ = requireExplicitStubs;
+        self.requiresExplicitStubs = requireExplicitStubs;
         self.klass = klass;
         self.cedar_double_impl = [[[CedarDoubleImpl alloc] initWithDouble:self] autorelease];
     }
@@ -25,7 +23,6 @@
 }
 
 - (void)dealloc {
-    require_explicit_stubs_ = nil;
     self.klass = nil;
     self.cedar_double_impl = nil;
     [super dealloc];
@@ -44,7 +41,7 @@
             // do nothing; everything's cool
         } break;
         case CDRStubMethodNotStubbed: {
-            if (require_explicit_stubs_) {
+            if (self.requiresExplicitStubs) {
                 NSString * selectorString = NSStringFromSelector(invocation.selector);
                 [[NSException exceptionWithName:NSInternalInconsistencyException
                                          reason:[NSString stringWithFormat:@"Invocation of unstubbed method: %@", selectorString]
@@ -53,7 +50,7 @@
             }
         } break;
         case CDRStubWrongArguments: {
-            if (require_explicit_stubs_) {
+            if (self.requiresExplicitStubs) {
                 NSString * reason = [NSString stringWithFormat:@"Wrong arguments supplied to stub"];
                 [[NSException exceptionWithName:NSInternalInconsistencyException
                                          reason:reason
@@ -77,6 +74,14 @@
 
 - (void)reset_sent_messages {
     [self.cedar_double_impl reset_sent_messages];
+}
+
+- (BOOL)can_stub:(SEL)selector {
+    return [self.klass instancesRespondToSelector:selector];
+}
+
+- (BOOL)has_stubbed_method_for:(SEL)selector {
+    return [self.cedar_double_impl has_stubbed_method_for:selector];
 }
 
 @end

--- a/Source/Doubles/CDRSpy.mm
+++ b/Source/Doubles/CDRSpy.mm
@@ -89,6 +89,10 @@
     return respondsToSelector;
 }
 
+- (BOOL)can_stub:(SEL)selector {
+    return [self respondsToSelector:selector];
+}
+
 #pragma mark - CedarDouble protocol
 
 - (Cedar::Doubles::StubbedMethod &)add_stub:(const Cedar::Doubles::StubbedMethod &)stubbed_method {

--- a/Source/Doubles/CedarDoubleImpl.mm
+++ b/Source/Doubles/CedarDoubleImpl.mm
@@ -53,7 +53,7 @@ static NSMutableArray *registeredDoubleImpls__ = nil;
 - (Cedar::Doubles::StubbedMethod &)add_stub:(const Cedar::Doubles::StubbedMethod &)stubbed_method {
     const SEL & selector = stubbed_method.selector();
 
-    if (![self.parent_double respondsToSelector:selector]) {
+    if (![self.parent_double can_stub:selector]) {
         [[NSException exceptionWithName:NSInternalInconsistencyException
                                  reason:[NSString stringWithFormat:@"Attempting to stub method <%s>, which double does not respond to", sel_getName(selector)]
                                userInfo:nil]
@@ -111,6 +111,11 @@ static NSMutableArray *registeredDoubleImpls__ = nil;
         }
     }
     return CDRStubWrongArguments;
+}
+
+- (BOOL)has_stubbed_method_for:(SEL)selector {
+    Cedar::Doubles::StubbedMethod::selector_map_t::iterator it = stubbed_methods_.find(selector);
+    return it != stubbed_methods_.end();
 }
 
 - (void)record_method_invocation:(NSInvocation *)invocation {

--- a/Source/Headers/Doubles/CDRClassFake.h
+++ b/Source/Headers/Doubles/CDRClassFake.h
@@ -6,4 +6,4 @@
 
 @end
 
-id CDR_fake_for(Class klass, bool require_explicit_stubs = true);
+id CDR_fake_for(Class klass, BOOL require_explicit_stubs = YES);

--- a/Source/Headers/Doubles/CDRFake.h
+++ b/Source/Headers/Doubles/CDRFake.h
@@ -4,12 +4,13 @@
 @interface CDRFake : NSObject<CedarDouble>
 
 @property (nonatomic, assign) Class klass;
+@property (nonatomic, assign) BOOL requiresExplicitStubs;
 
-- (id)initWithClass:(Class)klass requireExplicitStubs:(bool)requireExplicitStubs;
+- (id)initWithClass:(Class)klass requireExplicitStubs:(BOOL)requireExplicitStubs;
 
 @end
 
 #ifndef CEDAR_DOUBLES_COMPATIBILITY_MODE
 #define fake_for(x) CDR_fake_for((x))
-#define nice_fake_for(x) CDR_fake_for((x), false)
+#define nice_fake_for(x) CDR_fake_for((x), NO)
 #endif

--- a/Source/Headers/Doubles/CDRProtocolFake.h
+++ b/Source/Headers/Doubles/CDRProtocolFake.h
@@ -7,8 +7,8 @@
 
 @interface CDRProtocolFake : CDRFake
 
-- (id)initWithClass:(Class)klass forProtocol:(Protocol *)protocol requireExplicitStubs:(bool)requireExplicitStubs;
+- (id)initWithClass:(Class)klass forProtocol:(Protocol *)protocol requireExplicitStubs:(BOOL)requireExplicitStubs;
 
 @end
 
-id CDR_fake_for(Protocol *protocol, bool require_explicit_stubs = true);
+id CDR_fake_for(Protocol *protocol, BOOL require_explicit_stubs = YES);

--- a/Source/Headers/Doubles/CedarDouble.h
+++ b/Source/Headers/Doubles/CedarDouble.h
@@ -7,8 +7,12 @@ namespace Cedar { namespace Doubles {
 @protocol CedarDouble<NSObject>
 
 - (Cedar::Doubles::StubbedMethod &)add_stub:(const Cedar::Doubles::StubbedMethod &)stubbed_method;
+
 - (NSArray *)sent_messages;
 - (void)reset_sent_messages;
+
+- (BOOL)can_stub:(SEL)selector;
+- (BOOL)has_stubbed_method_for:(SEL)selector;
 
 @end
 

--- a/Source/Headers/Doubles/CedarDoubleImpl.h
+++ b/Source/Headers/Doubles/CedarDoubleImpl.h
@@ -23,5 +23,6 @@ typedef enum {
 - (Cedar::Doubles::StubbedMethod::selector_map_t &)stubbed_methods;
 - (CDRStubInvokeStatus)invoke_stubbed_method:(NSInvocation *)invocation;
 - (void)record_method_invocation:(NSInvocation *)invocation;
+- (BOOL)has_stubbed_method_for:(SEL)selector;
 
 @end

--- a/Spec/Doubles/CDRProtocolFakeSpec.mm
+++ b/Spec/Doubles/CDRProtocolFakeSpec.mm
@@ -61,9 +61,13 @@ describe(@"fake (protocol)", ^{
             });
         });
 
-        context(@"when asked if it responds to an optional protocol method", ^{
-            it(@"should return NO", ^{
+        describe(@"handling optional protocol methods", ^{
+            it(@"should not respond to unstubbed selectors", ^{
                 [fake respondsToSelector:@selector(whatIfIIncrementedBy:)] should equal(NO);
+            });
+
+            it(@"should raise exception when unstubbed optional method invoked", ^{
+                ^{ [fake whatIfIIncrementedBy:1]; } should raise_exception;
             });
 
             context(@"when the method is stubbed", ^{
@@ -71,7 +75,7 @@ describe(@"fake (protocol)", ^{
                     fake stub_method(@selector(whatIfIIncrementedBy:)).and_return((size_t)42);
                 });
 
-                it(@"should return YES", ^{
+                it(@"should return respond to its selector", ^{
                     [fake respondsToSelector:@selector(whatIfIIncrementedBy:)] should equal(YES);
                 });
             });


### PR DESCRIPTION
Implements more specific handling of optional protocol methods:
- Nice fakes will respond to optional protocol methods by default (as they already did)
- Non-nice fakes will not respond to optional protocol methods until they are stubbed, at which point they will respond to optional protocol method selectors.

This should help in test driving code which will interact with protocol implementations which may or may not implement optional methods.  This is especially helpful in framework/SDK development.
