### PR TITLE
Fix multiple stubs with different primitive args

### DIFF
--- a/Source/Doubles/StubbedMethod.mm
+++ b/Source/Doubles/StubbedMethod.mm
@@ -69,7 +69,7 @@ namespace Cedar { namespace Doubles {
         for (argument_it = arguments.begin(); argument_it != arguments.end(); ++argument_it) {
             Cedar::Doubles::Argument::shared_ptr_t argument_ptr = *argument_it;
 
-            if (*argument_ptr == *Arguments::anything) {
+            if (strcmp(typeid(*argument_ptr).name(), typeid(*Arguments::anything).name()) == 0) {
                 return true;
             }
         }

--- a/Spec/Doubles/CedarDoubleSharedExamples.mm
+++ b/Spec/Doubles/CedarDoubleSharedExamples.mm
@@ -244,6 +244,25 @@ sharedExamplesFor(@"a Cedar double", ^(NSDictionary *sharedContext) {
         });
 
         describe(@"argument expectations", ^{
+            context(@"when stubbing the same method multiple times with distinctly different primitive arguments", ^{
+                __block BOOL firstStubWasCalled, secondStubWasCalled;
+                beforeEach(^{
+                    firstStubWasCalled = secondStubWasCalled = NO;
+                    myDouble stub_method("incrementByInteger:").with(1).and_do(^(NSInvocation *) {
+                        firstStubWasCalled = YES;
+                    });
+                    myDouble stub_method("incrementByInteger:").with(3).and_do(^(NSInvocation *) {
+                        secondStubWasCalled = YES;
+                    });
+                });
+
+                it(@"should perform the stub action associated with those arguments when invoked with those arguments", ^{
+                    [myDouble incrementByInteger:3];
+                    secondStubWasCalled should be_truthy;
+                    firstStubWasCalled should_not be_truthy;
+                });
+            });
+
             context(@"when specified with .with(varargs)", ^{
                 NSNumber *arg1 = @1;;
                 NSNumber *arg2 = @2;

--- a/Spec/Doubles/SimpleIncrementer.h
+++ b/Spec/Doubles/SimpleIncrementer.h
@@ -8,6 +8,7 @@
 - (void)increment;
 - (void)incrementBy:(size_t)amount;
 - (void)incrementByNumber:(NSNumber *)number;
+- (void)incrementByInteger:(NSUInteger)number;
 - (void)incrementByABit:(size_t)aBit andABitMore:(NSNumber *)aBitMore;
 - (void)incrementWithException;
 - (void)methodWithBlock:(void(^)())blockArgument;

--- a/Spec/Doubles/SimpleIncrementer.m
+++ b/Spec/Doubles/SimpleIncrementer.m
@@ -25,6 +25,10 @@
     self.value += [number intValue];
 }
 
+- (void)incrementByInteger:(NSUInteger)integer {
+    self.value += integer;
+}
+
 - (void)incrementByABit:(size_t)aBit andABitMore:(NSNumber *)aBitMore {
     self.value += aBit + [aBitMore intValue];
 }


### PR DESCRIPTION
This fixes the broken test case, but I'd like some feedback on how to do this better.  In particular, I'm not super comfortable with using typeid().  I'd prefer line 72 on StubbedMethod.mm to be:

if (Arguments::anything.get() == argument_ptr.get()) {

This doesn't work because Arguments::anything doesn't always return a shared pointer to the same Arguments::AnyArgument instance.  Shouldn't it do that since it's statically initialized? (AnyArgument.h:24)
