### PR TITLE
Fixes KVO compliance of CDRClassFakes

### DIFF
--- a/Cedar.xcodeproj/project.pbxproj
+++ b/Cedar.xcodeproj/project.pbxproj
@@ -150,6 +150,7 @@
 		AE53B68117E7BCD300D83D5E /* CedarOrdinaryFakeSharedExamples.mm in Sources */ = {isa = PBXBuildFile; fileRef = AEE0665817315DB8003CA143 /* CedarOrdinaryFakeSharedExamples.mm */; };
 		AE53B68217E7BCE700D83D5E /* CedarNiceFakeSharedExamples.mm in Sources */ = {isa = PBXBuildFile; fileRef = AEE0665517315C20003CA143 /* CedarNiceFakeSharedExamples.mm */; };
 		AE53B68317E7BDA900D83D5E /* HaveReceivedSpec.mm in Sources */ = {isa = PBXBuildFile; fileRef = 6639A77A14C509FE00B564B7 /* HaveReceivedSpec.mm */; };
+		AE53B68417E7CD8D00D83D5E /* ObjectWithWeakDelegate.m in Sources */ = {isa = PBXBuildFile; fileRef = AE5218D2175979CA00A656BC /* ObjectWithWeakDelegate.m */; settings = {COMPILER_FLAGS = "-fobjc-arc"; }; };
 		AE597B4115B0638B00EEF305 /* InvocationMatcher.h in Headers */ = {isa = PBXBuildFile; fileRef = AE597B4015B0638B00EEF305 /* InvocationMatcher.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		AE597B4215B0638B00EEF305 /* InvocationMatcher.h in Headers */ = {isa = PBXBuildFile; fileRef = AE597B4015B0638B00EEF305 /* InvocationMatcher.h */; };
 		AE6F3F341458D7C100C98F1E /* BeGreaterThanSpec.mm in Sources */ = {isa = PBXBuildFile; fileRef = AE6F3F331458D7C100C98F1E /* BeGreaterThanSpec.mm */; };
@@ -1747,6 +1748,7 @@
 				AE8C87AE136245BB006C9305 /* ExpectFailureWithMessage.m in Sources */,
 				96EA1CBA142C6560001A78E0 /* CDRSpecFailureSpec.mm in Sources */,
 				AEF7301B13ECC4AE00786282 /* BeCloseToSpec.mm in Sources */,
+				AE53B68417E7CD8D00D83D5E /* ObjectWithWeakDelegate.m in Sources */,
 				AEF7301D13ECC4AE00786282 /* BeInstanceOfSpec.mm in Sources */,
 				AEF7301F13ECC4AE00786282 /* BeNilSpec.mm in Sources */,
 				AEF7302113ECC4AE00786282 /* BeSameInstanceAsSpec.mm in Sources */,

--- a/Source/Doubles/CDRClassFake.mm
+++ b/Source/Doubles/CDRClassFake.mm
@@ -30,6 +30,10 @@
     return self.klass;
 }
 
+- (void)setValue:(id)value forUndefinedKey:(NSString *)key {
+    /* fail silently unless stubbed */
+}
+
 @end
 
 id CDR_fake_for(Class klass, BOOL require_explicit_stubs /*= YES */) {

--- a/Spec/Doubles/CDRClassFakeSpec.mm
+++ b/Spec/Doubles/CDRClassFakeSpec.mm
@@ -1,6 +1,7 @@
 #import <Cedar/SpecHelper.h>
 #import "SimpleIncrementer.h"
 #import "ObjectWithForwardingTarget.h"
+#import "ObjectWithWeakDelegate.h"
 
 using namespace Cedar::Matchers;
 using namespace Cedar::Doubles;
@@ -135,7 +136,20 @@ describe(@"CDRClassFake", ^{
             } should raise_exception.with_reason([NSString stringWithFormat:@"Attempting to stub method <unforwardedUnimplementedMethod>, which double <%@> does not respond to", [fake description]]);
         });
     });
-});
 
+    describe(@"using Key Value Coding to set values on a class fake", ^{
+        __block ObjectWithWeakDelegate *niceFake;
+
+        beforeEach(^{
+            niceFake = nice_fake_for([ObjectWithWeakDelegate class]);
+        });
+
+        it(@"should not blow up, silently failing when setValue:forKey: is invoked", ^{
+            [niceFake setValue:nice_fake_for(@protocol(ExampleDelegate)) forKey:@"delegate"];
+
+            niceFake.delegate should be_nil;
+        });
+    });
+});
 
 SPEC_END


### PR DESCRIPTION
Previously setValue:forKey: would fail silently if invoked on a
CDRClassFake. This commit restores that behavior - otherwise we
throw a "class is not key value coding-compliant" exception.
