### PR TITLE
RaiseException matcher extended to handle NSException' name

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,4 @@ build
 .DS_Store
 .idea
 template-project
+DerivedData

--- a/Source/Headers/Matchers/Base/RaiseException.h
+++ b/Source/Headers/Matchers/Base/RaiseException.h
@@ -16,7 +16,7 @@ namespace Cedar { namespace Matchers {
         RaiseException & operator=(const RaiseException &);
 
     public:
-        explicit RaiseException(NSObject * = nil, Class = nil, bool = false, NSString * = nil);
+        explicit RaiseException(NSObject * = nil, Class = nil, bool = false, NSString * = nil, NSString * = nil);
         ~RaiseException();
         // Allow default copy ctor.
 
@@ -29,6 +29,9 @@ namespace Cedar { namespace Matchers {
         RaiseException & with_reason(NSString * const reason);
         RaiseException with_reason(NSString * const reason) const;
 
+        RaiseException & with_name(NSString * const name);
+        RaiseException with_name(NSString * const name) const;
+
         bool matches(empty_block_t) const;
 
     protected:
@@ -38,12 +41,14 @@ namespace Cedar { namespace Matchers {
         bool exception_matches_expected_class(NSObject * const exception) const;
         bool exception_matches_expected_instance(NSObject * const exception) const;
         bool exception_matches_expected_reason(NSObject * const exception) const;
+        bool exception_matches_expected_name(NSObject * const exception) const;
 
     private:
         const NSObject *expectedExceptionInstance_;
         const Class expectedExceptionClass_;
         bool allowSubclasses_;
         NSString *expectedReason_;
+        NSString *expectedName_;
     };
 
     RaiseException raise() __attribute__((deprecated)); // Please use raise_exception

--- a/Spec/Matchers/Base/RaiseExceptionSpec.mm
+++ b/Spec/Matchers/Base/RaiseExceptionSpec.mm
@@ -288,6 +288,78 @@ describe(@"raise_exception matcher", ^{
             });
         });
     });
+
+    context(@"with a name specified", ^{
+        NSString *name = @"CDRSpecException";
+
+        context(@"when the block throws an exception with the specified name", ^{
+            beforeEach(^{
+                exception = [NSException exceptionWithName:name reason:nil userInfo:nil];
+                block = [[^{
+                    [exception raise];
+                } copy] autorelease];
+            });
+
+            describe(@"positive match", ^{
+                it(@"should pass", ^{
+                    block should raise_exception.with_name(name);
+                });
+            });
+
+            describe(@"negative match", ^{
+                it(@"should fail with a sensible failure message", ^{
+                    expectFailureWithMessage([NSString stringWithFormat:@"Expected <%@> to not raise an exception with name <%@>", block, name], ^{
+                        block should_not raise_exception.with_name(name);
+                    });
+                });
+            });
+        });
+
+        context(@"when the block throws an exception with a different name", ^{
+            NSString *anotherName = @"CDRAnotherSpecException";
+
+            beforeEach(^{
+                exception = [NSException exceptionWithName:anotherName reason:nil userInfo:nil];
+                block = [[^{
+                    [exception raise];
+                } copy] autorelease];
+            });
+
+            describe(@"positive match", ^{
+                it(@"should fail with a sensible failure message", ^{
+                    expectFailureWithMessage([NSString stringWithFormat:@"Expected <%@> to raise an exception with name <%@>", block, name], ^{
+                        block should raise_exception.with_name(name);
+                    });
+                });
+            });
+
+            describe(@"negative match", ^{
+                it(@"should pass", ^{
+                    block should_not raise_exception.with_name(name);
+                });
+            });
+        });
+
+        context(@"when the block does not throw an exception", ^{
+            beforeEach(^{
+                block = [[^{} copy] autorelease];
+            });
+
+            describe(@"positive match", ^{
+                it(@"should fail with a sensible failure message", ^{
+                    expectFailureWithMessage([NSString stringWithFormat:@"Expected <%@> to raise an exception with name <%@>", block, name], ^{
+                        block should raise_exception.with_name(name);
+                    });
+                });
+            });
+
+            describe(@"negative match", ^{
+                it(@"should pass", ^{
+                    block should_not raise_exception.with_name(name);
+                });
+            });
+        });
+    });
 });
 
 SPEC_END


### PR DESCRIPTION
Added ability to check name of exception

``` objective-c
^{
//  throw something
} should raise_exception.with_name(NSInvalidArgumentException);
```
