### PR TITLE
Upgraded project to be compatible with the iOS 7 SDK.

### DIFF
--- a/Cedar.xcodeproj/project.pbxproj
+++ b/Cedar.xcodeproj/project.pbxproj
@@ -1519,7 +1519,7 @@
 		AEEE1FA611DC26EA00029872 /* Project object */ = {
 			isa = PBXProject;
 			attributes = {
-				LastUpgradeCheck = 0460;
+				LastUpgradeCheck = 0500;
 			};
 			buildConfigurationList = AEEE1FA911DC26EA00029872 /* Build configuration list for PBXProject "Cedar" */;
 			compatibilityVersion = "Xcode 3.2";
@@ -2065,7 +2065,6 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				ALWAYS_SEARCH_USER_PATHS = NO;
-				ARCHS = "$(ARCHS_STANDARD_32_BIT)";
 				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Developer";
 				COPY_PHASE_STRIP = NO;
 				GCC_C_LANGUAGE_STANDARD = gnu99;
@@ -2090,7 +2089,6 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				ALWAYS_SEARCH_USER_PATHS = NO;
-				ARCHS = "$(ARCHS_STANDARD_32_BIT)";
 				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Developer";
 				COPY_PHASE_STRIP = YES;
 				GCC_C_LANGUAGE_STANDARD = gnu99;
@@ -2113,7 +2111,6 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				ALWAYS_SEARCH_USER_PATHS = NO;
-				ARCHS = "$(ARCHS_STANDARD_32_BIT)";
 				BUNDLE_LOADER = "$(BUILT_PRODUCTS_DIR)/OCUnitApp.app/OCUnitApp";
 				FRAMEWORK_SEARCH_PATHS = (
 					"$(SDKROOT)/Developer/Library/Frameworks",
@@ -2152,7 +2149,6 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				ALWAYS_SEARCH_USER_PATHS = NO;
-				ARCHS = "$(ARCHS_STANDARD_32_BIT)";
 				BUNDLE_LOADER = "$(BUILT_PRODUCTS_DIR)/OCUnitApp.app/OCUnitApp";
 				FRAMEWORK_SEARCH_PATHS = (
 					"$(SDKROOT)/Developer/Library/Frameworks",
@@ -2189,21 +2185,26 @@
 		AEEE1FA711DC26EA00029872 /* Debug */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
-				ARCHS = "$(ARCHS_STANDARD_32_64_BIT)";
 				CLANG_CXX_LANGUAGE_STANDARD = "c++0x";
 				CLANG_CXX_LIBRARY = "libc++";
+				CLANG_WARN_BOOL_CONVERSION = YES;
 				CLANG_WARN_CONSTANT_CONVERSION = YES;
+				CLANG_WARN_EMPTY_BODY = YES;
 				CLANG_WARN_ENUM_CONVERSION = YES;
 				CLANG_WARN_INT_CONVERSION = YES;
 				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
 				COPY_PHASE_STRIP = NO;
 				GCC_TREAT_WARNINGS_AS_ERRORS = YES;
 				GCC_VERSION = com.apple.compilers.llvm.clang.1_0;
+				GCC_WARN_64_TO_32_BIT_CONVERSION = YES;
 				GCC_WARN_ABOUT_MISSING_NEWLINE = YES;
 				GCC_WARN_ABOUT_RETURN_TYPE = YES;
+				GCC_WARN_UNDECLARED_SELECTOR = YES;
 				GCC_WARN_UNINITIALIZED_AUTOS = YES;
+				GCC_WARN_UNUSED_FUNCTION = YES;
 				GCC_WARN_UNUSED_VARIABLE = YES;
 				IPHONEOS_DEPLOYMENT_TARGET = 5.0;
+				ONLY_ACTIVE_ARCH = YES;
 				OTHER_CPLUSPLUSFLAGS = (
 					"$(OTHER_CFLAGS)",
 					"-fobjc-call-cxx-cdtors",
@@ -2215,19 +2216,23 @@
 		AEEE1FA811DC26EA00029872 /* Release */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
-				ARCHS = "$(ARCHS_STANDARD_32_64_BIT)";
 				CLANG_CXX_LANGUAGE_STANDARD = "c++0x";
 				CLANG_CXX_LIBRARY = "libc++";
+				CLANG_WARN_BOOL_CONVERSION = YES;
 				CLANG_WARN_CONSTANT_CONVERSION = YES;
+				CLANG_WARN_EMPTY_BODY = YES;
 				CLANG_WARN_ENUM_CONVERSION = YES;
 				CLANG_WARN_INT_CONVERSION = YES;
 				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
 				COPY_PHASE_STRIP = YES;
 				GCC_TREAT_WARNINGS_AS_ERRORS = YES;
 				GCC_VERSION = com.apple.compilers.llvm.clang.1_0;
+				GCC_WARN_64_TO_32_BIT_CONVERSION = YES;
 				GCC_WARN_ABOUT_MISSING_NEWLINE = YES;
 				GCC_WARN_ABOUT_RETURN_TYPE = YES;
+				GCC_WARN_UNDECLARED_SELECTOR = YES;
 				GCC_WARN_UNINITIALIZED_AUTOS = YES;
+				GCC_WARN_UNUSED_FUNCTION = YES;
 				GCC_WARN_UNUSED_VARIABLE = YES;
 				IPHONEOS_DEPLOYMENT_TARGET = 5.0;
 				OTHER_CPLUSPLUSFLAGS = (
@@ -2349,7 +2354,6 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				ALWAYS_SEARCH_USER_PATHS = NO;
-				ARCHS = "$(ARCHS_STANDARD_32_BIT)";
 				COPY_PHASE_STRIP = NO;
 				GCC_DYNAMIC_NO_PIC = NO;
 				GCC_OPTIMIZATION_LEVEL = 0;
@@ -2362,7 +2366,6 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				ALWAYS_SEARCH_USER_PATHS = NO;
-				ARCHS = "$(ARCHS_STANDARD_32_BIT)";
 				COPY_PHASE_STRIP = YES;
 				DEBUG_INFORMATION_FORMAT = "dwarf-with-dsym";
 				PRODUCT_NAME = "Cedar-StaticLib";
@@ -2397,7 +2400,6 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				ALWAYS_SEARCH_USER_PATHS = NO;
-				ARCHS = "$(ARCHS_STANDARD_32_BIT)";
 				CODE_SIGN_IDENTITY = "iPhone Developer";
 				COPY_PHASE_STRIP = NO;
 				FRAMEWORK_SEARCH_PATHS = (
@@ -2434,7 +2436,6 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				ALWAYS_SEARCH_USER_PATHS = NO;
-				ARCHS = "$(ARCHS_STANDARD_32_BIT)";
 				CODE_SIGN_IDENTITY = "iPhone Developer";
 				COPY_PHASE_STRIP = YES;
 				DEBUG_INFORMATION_FORMAT = "dwarf-with-dsym";

--- a/Source/CDRDefaultReporter.m
+++ b/Source/CDRDefaultReporter.m
@@ -166,10 +166,10 @@
 
 - (void)printNestedFullTextForExample:(CDRExample *)example stateToken:(NSString *)token {
     static NSMutableArray *previousBranch = nil;
-    int previousBranchLength = previousBranch.count;
+    NSUInteger previousBranchLength = previousBranch.count;
 
     NSMutableArray *exampleBranch = [example fullTextInPieces];
-    int exampleBranchLength = exampleBranch.count;
+    NSUInteger exampleBranchLength = exampleBranch.count;
 
     BOOL onPreviousBranch = YES;
 

--- a/Source/CDRFunctions.m
+++ b/Source/CDRFunctions.m
@@ -62,11 +62,13 @@ BOOL CDRClassHasClassMethod(Class class, SEL selector) {
 
 void CDRDefineGlobalBeforeAndAfterEachBlocks() {
     [SpecHelper specHelper].globalBeforeEachClasses = CDRSelectClasses(^BOOL(Class class) {
-        return CDRClassHasClassMethod(class, @selector(beforeEach));
+        SEL beforeEachSelector = NSSelectorFromString(@"beforeEach");
+        return CDRClassHasClassMethod(class, beforeEachSelector);
     });
 
     [SpecHelper specHelper].globalAfterEachClasses = CDRSelectClasses(^BOOL(Class class) {
-        return CDRClassHasClassMethod(class, @selector(afterEach));
+        SEL afterEachSelector = NSSelectorFromString(@"afterEach");
+        return CDRClassHasClassMethod(class, afterEachSelector);
     });
 }
 

--- a/Source/CDROTestHelper.m
+++ b/Source/CDROTestHelper.m
@@ -10,9 +10,11 @@ int CDRRunOCUnitTests(id self, SEL _cmd, id ignored) {
     [[NSBundle allFrameworks] makeObjectsPerformSelector:@selector(principalClass)];
     [NSClassFromString(@"SenTestObserver") class];
 
-    id testSuite = [self performSelector:@selector(specifiedTestSuite)];
+    SEL specifiedTestSuiteSelector = NSSelectorFromString(@"specifiedTestSuite");
+    SEL hasSucceededSelector = NSSelectorFromString(@"specifiedTestSuite");
+    id testSuite = [self performSelector:specifiedTestSuiteSelector];
     id runResult = [testSuite performSelector:@selector(run)];
-    hasFailed = !(BOOL)[runResult performSelector:@selector(hasSucceeded)];
+    hasFailed = !(BOOL)[runResult performSelector:hasSucceededSelector];
 
     [pool release];
     return (int)hasFailed;
@@ -24,6 +26,7 @@ void CDRHijackOCUnitRun(IMP newImplementation) {
     Class senTestProbeClass = objc_getClass("SenTestProbe");
     if (senTestProbeClass) {
         Class senTestProbeMetaClass = objc_getMetaClass("SenTestProbe");
-        class_replaceMethod(senTestProbeMetaClass, @selector(runTests:), newImplementation, "v@:@");
+        SEL runTestsSelector = NSSelectorFromString(@"runTests:");
+        class_replaceMethod(senTestProbeMetaClass, runTestsSelector, newImplementation, "v@:@");
     }
 }

--- a/Source/CDRSpec.m
+++ b/Source/CDRSpec.m
@@ -149,13 +149,13 @@ void fail(NSString *reason) {
         return;
     }
 
-    int bestAddressIndex = [children indexOfObject:self.rootGroup];
+    NSUInteger bestAddressIndex = [children indexOfObject:self.rootGroup];
 
     // Matches closest example/group located on or below specifed line number
     // (only takes into account start of an example/group)
-    for (int i = 0, shortestDistance = -1; i < addresses.count; i++) {
-        NSUInteger address = [[addresses objectAtIndex:i] unsignedIntegerValue];
-        int distance = lineNumber - [self.symbolicator lineNumberForStackAddress:address];
+    for (NSInteger i = 0, shortestDistance = -1; i < addresses.count; i++) {
+        NSInteger address = [[addresses objectAtIndex:i] integerValue];
+        NSInteger distance = lineNumber - [self.symbolicator lineNumberForStackAddress:address];
 
         if (distance >= 0 && (distance < shortestDistance || shortestDistance == -1) ) {
             bestAddressIndex = i;

--- a/Source/SpecHelper.m
+++ b/Source/SpecHelper.m
@@ -46,7 +46,8 @@ static SpecHelper *specHelper__;
 }
 
 - (void)setUp {
-    if ([self respondsToSelector:@selector(beforeEach)]) {
+    SEL beforeEachSelector = NSSelectorFromString(@"beforeEach");
+    if ([self respondsToSelector:beforeEachSelector]) {
         NSLog(@"********************************************************************************");
         NSLog(@"Cedar no longer runs beforeEach blocks defined on the SpecHelper class.\n");
         NSLog(@"Rather than defining a global beforeEach on the SpecHelper instance,");
@@ -55,7 +56,7 @@ static SpecHelper *specHelper__;
         NSLog(@"********************************************************************************");
     }
 
-    [self.globalBeforeEachClasses makeObjectsPerformSelector:@selector(beforeEach)];
+    [self.globalBeforeEachClasses makeObjectsPerformSelector:beforeEachSelector];
 }
 
 - (CDRSpecBlock)subjectActionBlock {
@@ -63,7 +64,8 @@ static SpecHelper *specHelper__;
 }
 
 - (void)tearDown {
-    if ([self respondsToSelector:@selector(afterEach)]) {
+    SEL afterEachSelector = NSSelectorFromString(@"afterEach");
+    if ([self respondsToSelector:afterEachSelector]) {
         NSLog(@"********************************************************************************");
         NSLog(@"Cedar no longer runs afterEach blocks defined on the SpecHelper class.\n");
         NSLog(@"Rather than defining a global afterEach on the SpecHelper instance,");
@@ -72,7 +74,7 @@ static SpecHelper *specHelper__;
         NSLog(@"********************************************************************************");
     }
 
-    [self.globalAfterEachClasses makeObjectsPerformSelector:@selector(afterEach)];
+    [self.globalAfterEachClasses makeObjectsPerformSelector:afterEachSelector];
     [self.sharedExampleContext removeAllObjects];
 }
 

--- a/Source/iPhone/CedarApplicationDelegate.m
+++ b/Source/iPhone/CedarApplicationDelegate.m
@@ -21,8 +21,9 @@ int runSpecsWithinUIApplication() {
 
 void exitWithStatusFromUIApplication(int status) {
     UIApplication *application = [UIApplication sharedApplication];
-    if ([application respondsToSelector:@selector(_terminateWithStatus:)]) {
-        [application performSelector:@selector(_terminateWithStatus:) withObject:(id)status];
+    SEL _terminateWithStatusSelector = NSSelectorFromString(@"_terminateWithStatus:");
+    if ([application respondsToSelector:_terminateWithStatusSelector]) {
+        [application performSelector:_terminateWithStatusSelector withObject:(id)status];
     } else {
         exit(status);
     }

--- a/Source/iPhone/HeadlessSimulatorWorkaround.m
+++ b/Source/iPhone/HeadlessSimulatorWorkaround.m
@@ -5,17 +5,18 @@ void CDRSimulatorWorkaround_CreateFakePurpleWorkspacePort() {
     if (CFMessagePortCreateRemote(NULL, (CFStringRef)@"PurpleWorkspacePort") == NULL) {
         NSLog(@"No workspace port detected, creating one and disabling -[UIWindow _createContext]...");
         CFMessagePortCreateLocal(NULL, (CFStringRef)@"PurpleWorkspacePort", NULL, NULL, NULL);
-        class_replaceMethod([UIWindow class], @selector(_createContext), imp_implementationWithBlock(^{}), "v@:");
+        SEL _createContextSelector = NSSelectorFromString(@"_createContext");
+        class_replaceMethod([UIWindow class], _createContextSelector, imp_implementationWithBlock(^{}), "v@:");
     }
 }
 
 void CDRSimulatorWorkaround_HideBKSetAccelerometerClientEventsEnabled() {
     NSLog(@"Hiding 'BKSetAccelerometerClientEventsEnabled failed: (ipc/send) invalid destination port'");
-
+    SEL _serverWasRestartedSelector = NSSelectorFromString(@"_serverWasRestarted");
     // Found out via `sudo dtruss -p PID -s`
     class_replaceMethod(
         NSClassFromString(@"BKSAccelerometer"),
-        @selector(_serverWasRestarted),
+        _serverWasRestartedSelector,
         imp_implementationWithBlock(^{}),
         "v@:"
     );

--- a/Spec/Doubles/CDRClassFakeSpec.mm
+++ b/Spec/Doubles/CDRClassFakeSpec.mm
@@ -10,6 +10,7 @@ SPEC_BEGIN(CDRClassFakeSpec)
 
 sharedExamplesFor(@"a Cedar class fake", ^(NSDictionary *sharedContext) {
     __block SimpleIncrementer<CedarDouble> *fake;
+    SEL wibble_wobbleSelector = NSSelectorFromString(@"wibble_wobble");
 
     beforeEach(^{
         fake = [sharedContext objectForKey:@"double"];
@@ -24,7 +25,7 @@ sharedExamplesFor(@"a Cedar class fake", ^(NSDictionary *sharedContext) {
 
         context(@"when an instance method is not defined", ^{
             it(@"should return false", ^{
-                [fake respondsToSelector:@selector(wibble_wobble)] should_not be_truthy;
+                [fake respondsToSelector:wibble_wobbleSelector] should_not be_truthy;
             });
         });
     });

--- a/Spec/Doubles/CDRProtocolFakeSpec.mm
+++ b/Spec/Doubles/CDRProtocolFakeSpec.mm
@@ -23,7 +23,8 @@ sharedExamplesFor(@"a Cedar protocol fake", ^(NSDictionary *sharedContext) {
 
         context(@"when an instance method is not defined", ^{
             it(@"should return false", ^{
-                [fake respondsToSelector:@selector(wibble_wobble)] should_not be_truthy;
+                SEL wibble_wobbleSelector = NSSelectorFromString(@"wibble_wobble");
+                [fake respondsToSelector:wibble_wobbleSelector] should_not be_truthy;
             });
         });
     });

--- a/Spec/Doubles/CDRSpySpec.mm
+++ b/Spec/Doubles/CDRSpySpec.mm
@@ -95,8 +95,9 @@ describe(@"spy_on", ^{
     });
 
     it(@"should not change the methods the given object responds to", ^{
+        SEL wibbleSelector = NSSelectorFromString(@"wibble");
         [incrementer respondsToSelector:@selector(increment)] should be_truthy;
-        [incrementer respondsToSelector:@selector(wibble)] should_not be_truthy;
+        [incrementer respondsToSelector:wibbleSelector] should_not be_truthy;
     });
 
     it(@"should not affect other instances of the same class", ^{

--- a/Spec/Doubles/CedarDoubleSharedExamples.mm
+++ b/Spec/Doubles/CedarDoubleSharedExamples.mm
@@ -52,7 +52,7 @@ sharedExamplesFor(@"a Cedar double", ^(NSDictionary *sharedContext) {
             static NSInteger numInvocations = 2;
             myDouble stub_method("value");
 
-            int doubleRetainCount = myDouble.retainCount;
+            NSUInteger doubleRetainCount = myDouble.retainCount;
 
             // spies are allowed to increment the retain count of the double by 1
             // but should hand the retain over to the autorelease pool

--- a/Spec/Doubles/HaveReceivedSpec.mm
+++ b/Spec/Doubles/HaveReceivedSpec.mm
@@ -390,7 +390,7 @@ describe(@"have_received matcher", ^{
     });
 
     context(@"for a method that the object does not respond to", ^{
-        SEL method = @selector(noSuchMethod:);
+        SEL method = NSSelectorFromString(@"noSuchMethod:");
 
         it(@"should raise an exception due to an invalid expectation", ^{
             NSString *methodString = NSStringFromSelector(method);


### PR DESCRIPTION
Deferred creation of selectors to runtime and changed integer types to avoid compiler warnings.

Specs and focused specs run, but there are problems with the dynamic libraries and runtime services that are still causing problems with the iOSSpecs target.

iOSSpecs Target
- iOS 5.1 - all tests pass when run from within XCode
- iOS 6.1 - all tests pass when run from within XCode
- iOS 7.0 - 6 tests fail when run from within XCode

I have gotten mixed results when running the rake tasks, so for right now, I'm just focusing on getting everything working from within XCode.
