### PR TITLE
Added the explicit __gcov_flush() call to the applicationWillTerminate: ...

### DIFF
--- a/Source/iPhone/CedarApplicationDelegate.m
+++ b/Source/iPhone/CedarApplicationDelegate.m
@@ -4,6 +4,12 @@
 #import "CDRFunctions.h"
 #import <objc/runtime.h>
 
+#ifdef __IPHONE_7_0
+    /* Do this only for iOS SDK 7+:
+    -- Declare __gcov_flush, Grant the target process access to the supplied buffer */
+    extern void __gcov_flush(void);
+#endif
+
 int runSpecsWithinUIApplication() {
     int exitStatus;
 
@@ -62,6 +68,14 @@ void exitWithStatusFromUIApplication(int status) {
     [window_ makeKeyAndVisible];
 
     return NO;
+}
+
+- (void)applicationWillTerminate:(UIApplication *)application {
+#ifdef __IPHONE_7_0
+    /* Do this only for iOS SDK 7+:
+    -- Make the target copy it's buffer by calling __gcov_flush */
+    __gcov_flush();
+#endif
 }
 
 - (UIWindow *)window {


### PR DESCRIPTION
...method of the CedarApplicationDelegate class

**Note:** Can't run the specs at the moment because rake keeps throwing an error, but it _should_ work this way. Anyhow, we would really appreciate code coverage generation under cedar at the moment.
