### PR TITLE
Fixed failing specs

### DIFF
--- a/Cedar.xcodeproj/xcshareddata/xcschemes/OCUnitApp.xcscheme
+++ b/Cedar.xcodeproj/xcshareddata/xcschemes/OCUnitApp.xcscheme
@@ -1,0 +1,106 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Scheme
+   LastUpgradeVersion = "0500"
+   version = "1.3">
+   <BuildAction
+      parallelizeBuildables = "YES"
+      buildImplicitDependencies = "YES">
+      <BuildActionEntries>
+         <BuildActionEntry
+            buildForTesting = "YES"
+            buildForRunning = "YES"
+            buildForProfiling = "YES"
+            buildForArchiving = "YES"
+            buildForAnalyzing = "YES">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "96B5F9F5144A81A7000A6A5D"
+               BuildableName = "OCUnitApp.app"
+               BlueprintName = "OCUnitApp"
+               ReferencedContainer = "container:Cedar.xcodeproj">
+            </BuildableReference>
+         </BuildActionEntry>
+      </BuildActionEntries>
+   </BuildAction>
+   <TestAction
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      shouldUseLaunchSchemeArgsEnv = "YES"
+      buildConfiguration = "Debug">
+      <Testables>
+         <TestableReference
+            skipped = "NO">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "96B5FA10144A81A8000A6A5D"
+               BuildableName = "OCUnitAppTests.octest"
+               BlueprintName = "OCUnitAppTests"
+               ReferencedContainer = "container:Cedar.xcodeproj">
+            </BuildableReference>
+         </TestableReference>
+         <TestableReference
+            skipped = "NO">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "1F45A3C8180E4796003C1E36"
+               BuildableName = "XCUnitAppTests.xctest"
+               BlueprintName = "XCUnitAppTests"
+               ReferencedContainer = "container:Cedar.xcodeproj">
+            </BuildableReference>
+         </TestableReference>
+      </Testables>
+      <MacroExpansion>
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "96B5F9F5144A81A7000A6A5D"
+            BuildableName = "OCUnitApp.app"
+            BlueprintName = "OCUnitApp"
+            ReferencedContainer = "container:Cedar.xcodeproj">
+         </BuildableReference>
+      </MacroExpansion>
+   </TestAction>
+   <LaunchAction
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      launchStyle = "0"
+      useCustomWorkingDirectory = "NO"
+      buildConfiguration = "Debug"
+      ignoresPersistentStateOnLaunch = "NO"
+      debugDocumentVersioning = "YES"
+      allowLocationSimulation = "YES">
+      <BuildableProductRunnable>
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "96B5F9F5144A81A7000A6A5D"
+            BuildableName = "OCUnitApp.app"
+            BlueprintName = "OCUnitApp"
+            ReferencedContainer = "container:Cedar.xcodeproj">
+         </BuildableReference>
+      </BuildableProductRunnable>
+      <AdditionalOptions>
+      </AdditionalOptions>
+   </LaunchAction>
+   <ProfileAction
+      shouldUseLaunchSchemeArgsEnv = "YES"
+      savedToolIdentifier = ""
+      useCustomWorkingDirectory = "NO"
+      buildConfiguration = "Release"
+      debugDocumentVersioning = "YES">
+      <BuildableProductRunnable>
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "96B5F9F5144A81A7000A6A5D"
+            BuildableName = "OCUnitApp.app"
+            BlueprintName = "OCUnitApp"
+            ReferencedContainer = "container:Cedar.xcodeproj">
+         </BuildableReference>
+      </BuildableProductRunnable>
+   </ProfileAction>
+   <AnalyzeAction
+      buildConfiguration = "Debug">
+   </AnalyzeAction>
+   <ArchiveAction
+      buildConfiguration = "Release"
+      revealArchiveInOrganizer = "YES">
+   </ArchiveAction>
+</Scheme>

--- a/Cedar.xcodeproj/xcshareddata/xcschemes/Specs.xcscheme
+++ b/Cedar.xcodeproj/xcshareddata/xcschemes/Specs.xcscheme
@@ -1,0 +1,110 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Scheme
+   LastUpgradeVersion = "0500"
+   version = "1.3">
+   <BuildAction
+      parallelizeBuildables = "YES"
+      buildImplicitDependencies = "YES">
+      <BuildActionEntries>
+         <BuildActionEntry
+            buildForTesting = "YES"
+            buildForRunning = "YES"
+            buildForProfiling = "YES"
+            buildForArchiving = "YES"
+            buildForAnalyzing = "YES">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "AEEE218511DC28E200029872"
+               BuildableName = "Specs"
+               BlueprintName = "Specs"
+               ReferencedContainer = "container:Cedar.xcodeproj">
+            </BuildableReference>
+         </BuildActionEntry>
+         <BuildActionEntry
+            buildForTesting = "YES"
+            buildForRunning = "YES"
+            buildForProfiling = "YES"
+            buildForArchiving = "YES"
+            buildForAnalyzing = "YES">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "96158A85144A915E005895CE"
+               BuildableName = "OCUnitAppLogicTests.octest"
+               BlueprintName = "OCUnitAppLogicTests"
+               ReferencedContainer = "container:Cedar.xcodeproj">
+            </BuildableReference>
+         </BuildActionEntry>
+      </BuildActionEntries>
+   </BuildAction>
+   <TestAction
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      shouldUseLaunchSchemeArgsEnv = "YES"
+      buildConfiguration = "Debug">
+      <Testables>
+         <TestableReference
+            skipped = "NO">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "96158A85144A915E005895CE"
+               BuildableName = "OCUnitAppLogicTests.octest"
+               BlueprintName = "OCUnitAppLogicTests"
+               ReferencedContainer = "container:Cedar.xcodeproj">
+            </BuildableReference>
+         </TestableReference>
+      </Testables>
+      <MacroExpansion>
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "AEEE218511DC28E200029872"
+            BuildableName = "Specs"
+            BlueprintName = "Specs"
+            ReferencedContainer = "container:Cedar.xcodeproj">
+         </BuildableReference>
+      </MacroExpansion>
+   </TestAction>
+   <LaunchAction
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      launchStyle = "0"
+      useCustomWorkingDirectory = "NO"
+      buildConfiguration = "Debug"
+      ignoresPersistentStateOnLaunch = "NO"
+      debugDocumentVersioning = "YES"
+      allowLocationSimulation = "YES">
+      <BuildableProductRunnable>
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "AEEE218511DC28E200029872"
+            BuildableName = "Specs"
+            BlueprintName = "Specs"
+            ReferencedContainer = "container:Cedar.xcodeproj">
+         </BuildableReference>
+      </BuildableProductRunnable>
+      <AdditionalOptions>
+      </AdditionalOptions>
+   </LaunchAction>
+   <ProfileAction
+      shouldUseLaunchSchemeArgsEnv = "YES"
+      savedToolIdentifier = ""
+      useCustomWorkingDirectory = "NO"
+      buildConfiguration = "Release"
+      debugDocumentVersioning = "YES">
+      <BuildableProductRunnable>
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "AEEE218511DC28E200029872"
+            BuildableName = "Specs"
+            BlueprintName = "Specs"
+            ReferencedContainer = "container:Cedar.xcodeproj">
+         </BuildableReference>
+      </BuildableProductRunnable>
+   </ProfileAction>
+   <AnalyzeAction
+      buildConfiguration = "Debug">
+   </AnalyzeAction>
+   <ArchiveAction
+      buildConfiguration = "Release"
+      revealArchiveInOrganizer = "YES">
+   </ArchiveAction>
+</Scheme>

--- a/Source/CDRSymbolicator.m
+++ b/Source/CDRSymbolicator.m
@@ -187,7 +187,7 @@ NSUInteger CDRCallerStackAddress() {
             userInfo:nil] raise];
     }
 
-    NSMutableArray *arguments = [NSMutableArray arrayWithObjects:@"/Applications/Xcode.app/Contents/Developer/usr/bin/atos", @"-o", self.executablePath, nil];
+    NSMutableArray *arguments = [NSMutableArray arrayWithObjects:@"-o", self.executablePath, nil];
 
     // Position-independent executables addresses need to be adjusted hence the slide argument
     // https://developer.apple.com/library/mac/#technotes/tn2004/tn2123.html
@@ -198,7 +198,7 @@ NSUInteger CDRCallerStackAddress() {
         [arguments addObject:[NSString stringWithFormat:@"%lx", (long)address.unsignedIntegerValue]];
     }
 
-    NSString *output = [self.class shellOutWithCommand:@"/usr/bin/xcrun" arguments:arguments];
+    NSString *output = [self.class shellOutWithCommand:@"/Applications/Xcode.app/Contents/Developer/usr/bin/atos" arguments:arguments];
     self.outputLines = [output componentsSeparatedByString:@"\n"];
 }
 


### PR DESCRIPTION
- Shared test bundle schemes.
- Removed xcrun indirection for atos, which can cause failures on test bundles for fresh clones.
