### PR TITLE
Attempt to use a valid Ruby Module name in Rakefile

### DIFF
--- a/CodeSnippetsAndTemplates/Templates/Project Templates/Cedar/OSX Cedar Spec Suite.xctemplate/Rakefile
+++ b/CodeSnippetsAndTemplates/Templates/Project Templates/Cedar/OSX Cedar Spec Suite.xctemplate/Rakefile
@@ -1,6 +1,6 @@
 require 'pathname'
 
-module ___PACKAGENAME___
+module ___PACKAGENAMEASIDENTIFIER___
   SPECS_TARGET_NAME = "___PACKAGENAME___"
   CONFIGURATION = "Release"
 
@@ -60,19 +60,18 @@ module ___PACKAGENAME___
 end
 
 desc "Clean build directory"
-task :clean____PACKAGENAME___ do
-  ___PACKAGENAME___.system_or_exit "rm -rf #{___PACKAGENAME___::BUILD_DIR}/*", ___PACKAGENAME___.output_file("clean")
+task :clean____PACKAGENAMEASIDENTIFIER___ do
+  ___PACKAGENAMEASIDENTIFIER___.system_or_exit "rm -rf #{___PACKAGENAMEASIDENTIFIER___::BUILD_DIR}/*", ___PACKAGENAMEASIDENTIFIER___.output_file("clean")
 end
 
-desc "Build ___PACKAGENAME___ Specs"
-task :build____PACKAGENAME___ do
-  ___PACKAGENAME___.system_or_exit(%Q[pushd #{___PACKAGENAME___::PROJECT_ROOT} ; xcodebuild -target #{___PACKAGENAME___::SPECS_TARGET_NAME} -configuration #{___PACKAGENAME___::CONFIGURATION} build SYMROOT=#{___PACKAGENAME___::BUILD_DIR} ; popd ], ___PACKAGENAME___.output_file("___PACKAGENAME___"))
+desc "Build ___PACKAGENAMEASIDENTIFIER___ Specs"
+task :build____PACKAGENAMEASIDENTIFIER___ do
+  ___PACKAGENAMEASIDENTIFIER___.system_or_exit(%Q[pushd #{___PACKAGENAMEASIDENTIFIER___::PROJECT_ROOT} ; xcodebuild -target #{___PACKAGENAMEASIDENTIFIER___::SPECS_TARGET_NAME} -configuration #{___PACKAGENAMEASIDENTIFIER___::CONFIGURATION} build SYMROOT=#{___PACKAGENAMEASIDENTIFIER___::BUILD_DIR} ; popd ], ___PACKAGENAMEASIDENTIFIER___.output_file("___PACKAGENAME___"))
 end
 
-desc "Run ___PACKAGENAME___ Specs"
-task :___PACKAGENAME___ => :build____PACKAGENAME___ do
-  ___PACKAGENAME___.with_env_vars("DYLD_FRAMEWORK_PATH" => ___PACKAGENAME___.build_dir, "CEDAR_REPORTER_CLASS" => "CDRColorizedReporter") do
-    ___PACKAGENAME___.system_or_exit(File.join(___PACKAGENAME___.build_dir, ___PACKAGENAME___::SPECS_TARGET_NAME))
+desc "Run ___PACKAGENAMEASIDENTIFIER___ Specs"
+task :___PACKAGENAMEASIDENTIFIER___ => :build____PACKAGENAMEASIDENTIFIER___ do
+  ___PACKAGENAMEASIDENTIFIER___.with_env_vars("DYLD_FRAMEWORK_PATH" => ___PACKAGENAMEASIDENTIFIER___.build_dir, "CEDAR_REPORTER_CLASS" => "CDRColorizedReporter") do
+    ___PACKAGENAMEASIDENTIFIER___.system_or_exit(File.join(___PACKAGENAMEASIDENTIFIER___.build_dir, ___PACKAGENAMEASIDENTIFIER___::SPECS_TARGET_NAME))
   end
 end
-

--- a/CodeSnippetsAndTemplates/Templates/Project Templates/Cedar/OSX Cedar Testing Bundle.xctemplate/Rakefile
+++ b/CodeSnippetsAndTemplates/Templates/Project Templates/Cedar/OSX Cedar Testing Bundle.xctemplate/Rakefile
@@ -1,6 +1,6 @@
 require 'pathname'
 
-module ___PACKAGENAME___
+module ___PACKAGENAMEASIDENTIFIER___
   SPECS_TARGET_NAME = "___PACKAGENAME___"
   CONFIGURATION = "Release"
 
@@ -60,14 +60,13 @@ module ___PACKAGENAME___
 end
 
 desc "Clean build directory"
-task :clean____PACKAGENAME___ do
-  ___PACKAGENAME___.system_or_exit "rm -rf #{___PACKAGENAME___::BUILD_DIR}/*", ___PACKAGENAME___.output_file("clean")
+task :clean____PACKAGENAMEASIDENTIFIER___ do
+  ___PACKAGENAMEASIDENTIFIER___.system_or_exit "rm -rf #{___PACKAGENAMEASIDENTIFIER___::BUILD_DIR}/*", ___PACKAGENAMEASIDENTIFIER___.output_file("clean")
 end
 
-desc "Build and run ___PACKAGENAME___ OCUnit logic specs"
-task :___PACKAGENAME___ => :clean____PACKAGENAME___ do
-  ___PACKAGENAME___.with_env_vars("CEDAR_REPORTER_CLASS" => "CDRColorizedReporter") do
-    ___PACKAGENAME___.system_or_exit "pushd #{___PACKAGENAME___::PROJECT_ROOT} ; xcodebuild -target #{___PACKAGENAME___::SPECS_TARGET_NAME} -configuration #{___PACKAGENAME___::CONFIGURATION} -arch x86_64 build TEST_AFTER_BUILD=YES SYMROOT='#{___PACKAGENAME___::BUILD_DIR}' ; popd", ___PACKAGENAME___.output_file("___PACKAGENAME___")
+desc "Build and run ___PACKAGENAMEASIDENTIFIER___ OCUnit logic specs"
+task :___PACKAGENAMEASIDENTIFIER___ => :clean____PACKAGENAMEASIDENTIFIER___ do
+  ___PACKAGENAMEASIDENTIFIER___.with_env_vars("CEDAR_REPORTER_CLASS" => "CDRColorizedReporter") do
+    ___PACKAGENAMEASIDENTIFIER___.system_or_exit "pushd #{___PACKAGENAMEASIDENTIFIER___::PROJECT_ROOT} ; xcodebuild -target #{___PACKAGENAMEASIDENTIFIER___::SPECS_TARGET_NAME} -configuration #{___PACKAGENAMEASIDENTIFIER___::CONFIGURATION} -arch x86_64 build TEST_AFTER_BUILD=YES SYMROOT='#{___PACKAGENAMEASIDENTIFIER___::BUILD_DIR}' ; popd", ___PACKAGENAMEASIDENTIFIER___.output_file("___PACKAGENAME___")
   end
 end
-

--- a/CodeSnippetsAndTemplates/Templates/Project Templates/Cedar/iOS Cedar Spec Suite.xctemplate/Rakefile
+++ b/CodeSnippetsAndTemplates/Templates/Project Templates/Cedar/iOS Cedar Spec Suite.xctemplate/Rakefile
@@ -1,7 +1,7 @@
 require 'pathname'
 require 'tmpdir'
 
-module ___PACKAGENAME___
+module ___PACKAGENAMEASIDENTIFIER___
   UI_SPECS_TARGET_NAME = "___PACKAGENAME___"
   CONFIGURATION = "Release"
 
@@ -80,30 +80,29 @@ module ___PACKAGENAME___
 end
 
 desc "Clean build directory"
-task :clean____PACKAGENAME___ do
-  ___PACKAGENAME___.system_or_exit "rm -rf #{___PACKAGENAME___::BUILD_DIR}/*", ___PACKAGENAME___.output_file("clean")
+task :clean____PACKAGENAMEASIDENTIFIER___ do
+  ___PACKAGENAMEASIDENTIFIER___.system_or_exit "rm -rf #{___PACKAGENAMEASIDENTIFIER___::BUILD_DIR}/*", ___PACKAGENAMEASIDENTIFIER___.output_file("clean")
 end
 
-desc "Build ___PACKAGENAME___"
-task :build____PACKAGENAME___ => :clean____PACKAGENAME___ do
-  ___PACKAGENAME___.kill_simulator
-  ___PACKAGENAME___.system_or_exit "pushd #{___PACKAGENAME___::PROJECT_ROOT} && xcodebuild -target #{___PACKAGENAME___::UI_SPECS_TARGET_NAME} -configuration #{___PACKAGENAME___::CONFIGURATION} -sdk iphonesimulator build && popd", ___PACKAGENAME___.output_file("___PACKAGENAME___")
+desc "Build ___PACKAGENAMEASIDENTIFIER___"
+task :build____PACKAGENAMEASIDENTIFIER___ => :clean____PACKAGENAMEASIDENTIFIER___ do
+  ___PACKAGENAMEASIDENTIFIER___.kill_simulator
+  ___PACKAGENAMEASIDENTIFIER___.system_or_exit "pushd #{___PACKAGENAMEASIDENTIFIER___::PROJECT_ROOT} && xcodebuild -target #{___PACKAGENAMEASIDENTIFIER___::UI_SPECS_TARGET_NAME} -configuration #{___PACKAGENAMEASIDENTIFIER___::CONFIGURATION} -sdk iphonesimulator build && popd", ___PACKAGENAMEASIDENTIFIER___.output_file("___PACKAGENAME___")
 end
 
-desc "Run ___PACKAGENAME___"
-task :___PACKAGENAME___ => :build____PACKAGENAME___ do
+desc "Run ___PACKAGENAMEASIDENTIFIER___"
+task :___PACKAGENAMEASIDENTIFIER___ => :build____PACKAGENAMEASIDENTIFIER___ do
   env_vars = {
-    "DYLD_ROOT_PATH" => ___PACKAGENAME___.deployment_target_sdk_dir,
-    "IPHONE_SIMULATOR_ROOT" => ___PACKAGENAME___.deployment_target_sdk_dir,
+    "DYLD_ROOT_PATH" => ___PACKAGENAMEASIDENTIFIER___.deployment_target_sdk_dir,
+    "IPHONE_SIMULATOR_ROOT" => ___PACKAGENAMEASIDENTIFIER___.deployment_target_sdk_dir,
     "CFFIXED_USER_HOME" => Dir.tmpdir,
     "CEDAR_HEADLESS_SPECS" => "1",
     "CEDAR_REPORTER_CLASS" => "CDRColorizedReporter"
   }
 
-  app_path = File.join(___PACKAGENAME___.build_dir("-iphonesimulator"), "#{___PACKAGENAME___::UI_SPECS_TARGET_NAME}.app")
+  app_path = File.join(___PACKAGENAMEASIDENTIFIER___.build_dir("-iphonesimulator"), "#{___PACKAGENAMEASIDENTIFIER___::UI_SPECS_TARGET_NAME}.app")
 
-  ___PACKAGENAME___.with_env_vars(env_vars) do
-    ___PACKAGENAME___.system_or_exit "#{File.join(___PACKAGENAME___.build_dir("-iphonesimulator"), "#{___PACKAGENAME___::UI_SPECS_TARGET_NAME}.app", ___PACKAGENAME___::UI_SPECS_TARGET_NAME)} -RegisterForSystemEvents";
+  ___PACKAGENAMEASIDENTIFIER___.with_env_vars(env_vars) do
+    ___PACKAGENAMEASIDENTIFIER___.system_or_exit "#{File.join(___PACKAGENAMEASIDENTIFIER___.build_dir("-iphonesimulator"), "#{___PACKAGENAMEASIDENTIFIER___::UI_SPECS_TARGET_NAME}.app", ___PACKAGENAMEASIDENTIFIER___::UI_SPECS_TARGET_NAME)} -RegisterForSystemEvents";
   end
 end
-

--- a/CodeSnippetsAndTemplates/Templates/Project Templates/Cedar/iOS Cedar Testing Bundle.xctemplate/Rakefile
+++ b/CodeSnippetsAndTemplates/Templates/Project Templates/Cedar/iOS Cedar Testing Bundle.xctemplate/Rakefile
@@ -1,7 +1,7 @@
 require 'pathname'
 require 'tmpdir'
 
-module ___PACKAGENAME___
+module ___PACKAGENAMEASIDENTIFIER___
   UI_SPECS_TARGET_NAME = "___PACKAGENAME___"
   CONFIGURATION = "Release"
 
@@ -80,33 +80,32 @@ module ___PACKAGENAME___
 end
 
 desc "Clean build directory"
-task :clean____PACKAGENAME___ do
-  ___PACKAGENAME___.system_or_exit "rm -rf #{___PACKAGENAME___::BUILD_DIR}/*", ___PACKAGENAME___.output_file("clean")
+task :clean____PACKAGENAMEASIDENTIFIER___ do
+  ___PACKAGENAMEASIDENTIFIER___.system_or_exit "rm -rf #{___PACKAGENAMEASIDENTIFIER___::BUILD_DIR}/*", ___PACKAGENAMEASIDENTIFIER___.output_file("clean")
 end
 
-desc "Build ___PACKAGENAME___ OCUnit application specs"
-task :build____PACKAGENAME___ => :clean____PACKAGENAME___ do
-  ___PACKAGENAME___.kill_simulator
-  ___PACKAGENAME___.system_or_exit "pushd #{___PACKAGENAME___::PROJECT_ROOT} && xcodebuild -target ___VARIABLE_testTargetName___ -configuration #{___PACKAGENAME___::CONFIGURATION} -sdk iphonesimulator#{___PACKAGENAME___.deployment_target_sdk_version} build TEST_AFTER_BUILD=NO GCC_SYMBOLS_PRIVATE_EXTERN=NO SYMROOT='#{___PACKAGENAME___::BUILD_DIR}' && popd", ___PACKAGENAME___.output_file("___PACKAGENAME___-AppBuild")
-  ___PACKAGENAME___.system_or_exit "pushd #{___PACKAGENAME___::PROJECT_ROOT} && xcodebuild -target #{___PACKAGENAME___::UI_SPECS_TARGET_NAME} -configuration #{___PACKAGENAME___::CONFIGURATION} -sdk iphonesimulator#{___PACKAGENAME___.deployment_target_sdk_version} build GCC_SYMBOLS_PRIVATE_EXTERN=NO TEST_AFTER_BUILD=NO SYMROOT='#{___PACKAGENAME___::BUILD_DIR}' && popd", ___PACKAGENAME___.output_file("___PACKAGENAME___-SpecBuild")
+desc "Build ___PACKAGENAMEASIDENTIFIER___ OCUnit application specs"
+task :build____PACKAGENAMEASIDENTIFIER___ => :clean____PACKAGENAMEASIDENTIFIER___ do
+  ___PACKAGENAMEASIDENTIFIER___.kill_simulator
+  ___PACKAGENAMEASIDENTIFIER___.system_or_exit "pushd #{___PACKAGENAMEASIDENTIFIER___::PROJECT_ROOT} && xcodebuild -target ___VARIABLE_testTargetName___ -configuration #{___PACKAGENAMEASIDENTIFIER___::CONFIGURATION} -sdk iphonesimulator#{___PACKAGENAMEASIDENTIFIER___.deployment_target_sdk_version} build TEST_AFTER_BUILD=NO GCC_SYMBOLS_PRIVATE_EXTERN=NO SYMROOT='#{___PACKAGENAMEASIDENTIFIER___::BUILD_DIR}' && popd", ___PACKAGENAMEASIDENTIFIER___.output_file("___PACKAGENAME___-AppBuild")
+  ___PACKAGENAMEASIDENTIFIER___.system_or_exit "pushd #{___PACKAGENAMEASIDENTIFIER___::PROJECT_ROOT} && xcodebuild -target #{___PACKAGENAMEASIDENTIFIER___::UI_SPECS_TARGET_NAME} -configuration #{___PACKAGENAMEASIDENTIFIER___::CONFIGURATION} -sdk iphonesimulator#{___PACKAGENAMEASIDENTIFIER___.deployment_target_sdk_version} build GCC_SYMBOLS_PRIVATE_EXTERN=NO TEST_AFTER_BUILD=NO SYMROOT='#{___PACKAGENAMEASIDENTIFIER___::BUILD_DIR}' && popd", ___PACKAGENAMEASIDENTIFIER___.output_file("___PACKAGENAME___-SpecBuild")
 end
 
-desc "Run ___PACKAGENAME___ OCUnit application specs"
-task :___PACKAGENAME___ => :build____PACKAGENAME___ do
+desc "Run ___PACKAGENAMEASIDENTIFIER___ OCUnit application specs"
+task :___PACKAGENAMEASIDENTIFIER___ => :build____PACKAGENAMEASIDENTIFIER___ do
   env_vars = {
-    "DYLD_ROOT_PATH" => ___PACKAGENAME___.deployment_target_sdk_dir,
-    "DYLD_INSERT_LIBRARIES" => "#{___PACKAGENAME___.xcode_developer_dir}/Library/PrivateFrameworks/IDEBundleInjection.framework/IDEBundleInjection",
-    "DYLD_FALLBACK_LIBRARY_PATH" => ___PACKAGENAME___.deployment_target_sdk_dir,
-    "XCInjectBundle" => "#{File.join(___PACKAGENAME___.build_dir("-iphonesimulator"), "#{___PACKAGENAME___::UI_SPECS_TARGET_NAME}.octest")}",
-    "XCInjectBundleInto" => "#{File.join(___PACKAGENAME___.build_dir("-iphonesimulator"), "___VARIABLE_testTargetName___.app/___VARIABLE_testTargetName___")}",
-    "IPHONE_SIMULATOR_ROOT" => ___PACKAGENAME___.deployment_target_sdk_dir,
+    "DYLD_ROOT_PATH" => ___PACKAGENAMEASIDENTIFIER___.deployment_target_sdk_dir,
+    "DYLD_INSERT_LIBRARIES" => "#{___PACKAGENAMEASIDENTIFIER___.xcode_developer_dir}/Library/PrivateFrameworks/IDEBundleInjection.framework/IDEBundleInjection",
+    "DYLD_FALLBACK_LIBRARY_PATH" => ___PACKAGENAMEASIDENTIFIER___.deployment_target_sdk_dir,
+    "XCInjectBundle" => "#{File.join(___PACKAGENAMEASIDENTIFIER___.build_dir("-iphonesimulator"), "#{___PACKAGENAMEASIDENTIFIER___::UI_SPECS_TARGET_NAME}.octest")}",
+    "XCInjectBundleInto" => "#{File.join(___PACKAGENAMEASIDENTIFIER___.build_dir("-iphonesimulator"), "___VARIABLE_testTargetName___.app/___VARIABLE_testTargetName___")}",
+    "IPHONE_SIMULATOR_ROOT" => ___PACKAGENAMEASIDENTIFIER___.deployment_target_sdk_dir,
     "CFFIXED_USER_HOME" => Dir.tmpdir,
     "CEDAR_HEADLESS_SPECS" => "1",
     "CEDAR_REPORTER_CLASS" => "CDRColorizedReporter",
   }
 
-  ___PACKAGENAME___.with_env_vars(env_vars) do
-    ___PACKAGENAME___.system_or_exit "#{File.join(___PACKAGENAME___.build_dir("-iphonesimulator"), "___VARIABLE_testTargetName___.app/___VARIABLE_testTargetName___")} -RegisterForSystemEvents -SenTest All";
+  ___PACKAGENAMEASIDENTIFIER___.with_env_vars(env_vars) do
+    ___PACKAGENAMEASIDENTIFIER___.system_or_exit "#{File.join(___PACKAGENAMEASIDENTIFIER___.build_dir("-iphonesimulator"), "___VARIABLE_testTargetName___.app/___VARIABLE_testTargetName___")} -RegisterForSystemEvents -SenTest All";
   end
 end
-


### PR DESCRIPTION
I discovered this bug when I added cedar to one of my projects and created a target named "AppName specs", and the resulting `Rakefile` looked something like

```
module AppName specs 
  SPECS_TARGET_NAME = "AppName specs"
  ... et cetera ... 
end
```

I've tried to only replace the instances of `___PACKAGENAME___` with `___PACKAGENAMEASIDENTIFIER___` when it would refer to the module, not to the actual target, or any generated directories.

NB: This still won't work if your spec target starts with anything but a capital letter, but it will support targets with spaces, as well as unicode.

Oh, and for what it's worth, I found out about this template variable [here](https://sites.google.com/site/avrxinu/project-definition/xcode-4-0-templates), but I'm open to another approach to fixing this. Maybe the module name doesn't need to be dynamically based on the target name?
