### PR TITLE
Fix issues generating coverage reports on Xcode 5

### DIFF
--- a/Source/CDRFunctions.m
+++ b/Source/CDRFunctions.m
@@ -208,13 +208,14 @@ int runSpecsWithCustomExampleReporters(NSArray *reporters) {
 
         [groups makeObjectsPerformSelector:@selector(run)];
 
-        __gcov_flush();
-
         int result = 0;
         for (id<CDRExampleReporter> reporter in reporters) {
             [reporter runDidComplete];
             result |= [reporter result];
         }
+
+        __gcov_flush();
+
         return result;
     }
 }


### PR DESCRIPTION
- Provide a weak implementation of __gcov_flush() so we don't force everyone to use test coverage.
- Perform flush in common spec running function which is used by both test bundles and suites.
- Thanks to @nemesis and @PaulTaykalo for diagnosis and work on prior
  patches
