### PR TITLE
Adds method to get past sent message's arguments for doubles

### DIFF
--- a/Source/Doubles/CDRFake.mm
+++ b/Source/Doubles/CDRFake.mm
@@ -90,4 +90,8 @@
     return [self.cedar_double_impl has_stubbed_method_for:selector];
 }
 
+- (void)get_argument:(void *)argument at_index:(NSUInteger)index for_last_invocation_of_selector:(SEL)selector {
+    [self.cedar_double_impl get_argument:argument at_index:index for_last_invocation_of_selector:selector];
+}
+
 @end

--- a/Source/Doubles/CDRSpy.mm
+++ b/Source/Doubles/CDRSpy.mm
@@ -147,6 +147,10 @@
     [self.cedar_double_impl reset_sent_messages];
 }
 
+- (void)get_argument:(void *)argument at_index:(NSUInteger)index for_last_invocation_of_selector:(SEL)selector {
+    [self.cedar_double_impl get_argument:argument at_index:index for_last_invocation_of_selector:selector];
+}
+
 #pragma mark - Private interface
 
 - (CedarDoubleImpl *)cedar_double_impl {

--- a/Source/Doubles/CedarDoubleImpl.mm
+++ b/Source/Doubles/CedarDoubleImpl.mm
@@ -120,6 +120,21 @@ static NSMutableArray *registeredDoubleImpls__ = nil;
     [self.sent_messages addObject:invocation];
 }
 
+- (void)get_argument:(void *)argument at_index:(NSUInteger)index for_last_invocation_of_selector:(SEL)selector {
+    NSInvocation *lastMessage = [[[self sent_messages] filteredArrayUsingPredicate:[NSPredicate predicateWithBlock:^BOOL(NSInvocation *invocation, NSDictionary *bindings) {
+        return invocation.selector == selector;
+    }]] lastObject];
+
+    if (!lastMessage) {
+        [[NSException exceptionWithName:NSInternalInconsistencyException
+                                 reason:[NSString stringWithFormat:@"Attempting to get an argument for method <%s>, which double <%@> has not yet received", sel_getName(selector), [self.parent_double description]]
+                               userInfo:nil]
+         raise];
+    }
+
+    [lastMessage getArgument:argument atIndex:index + 2];
+}
+
 #pragma mark - Private interface
 
 - (Cedar::Doubles::StubbedMethod &)add_stubbed_method:(const Cedar::Doubles::StubbedMethod &)stubbed_method at_vector_location:(Cedar::Doubles::StubbedMethod::stubbed_method_vector_t::iterator)iterator {

--- a/Source/Headers/Doubles/CedarDouble.h
+++ b/Source/Headers/Doubles/CedarDouble.h
@@ -13,6 +13,7 @@ namespace Cedar { namespace Doubles {
 
 - (BOOL)can_stub:(SEL)selector;
 - (BOOL)has_stubbed_method_for:(SEL)selector;
+- (void)get_argument:(void *)argument at_index:(NSUInteger)index for_last_invocation_of_selector:(SEL)selector;
 
 @end
 

--- a/Source/Headers/Doubles/CedarDoubleImpl.h
+++ b/Source/Headers/Doubles/CedarDoubleImpl.h
@@ -28,5 +28,6 @@ typedef enum {
 - (CDRStubInvokeStatus)invoke_stubbed_method:(NSInvocation *)invocation;
 - (void)record_method_invocation:(NSInvocation *)invocation;
 - (BOOL)has_stubbed_method_for:(SEL)selector;
+- (void)get_argument:(void *)argument at_index:(NSUInteger)index for_last_invocation_of_selector:(SEL)selector;
 
 @end

--- a/Spec/Doubles/CedarDoubleARCSharedExamples.mm
+++ b/Spec/Doubles/CedarDoubleARCSharedExamples.mm
@@ -33,13 +33,13 @@ sharedExamplesFor(@"a Cedar double when used with ARC", ^(NSDictionary *sharedCo
 
                 dispatch_group_async(group, queue, ^{
                     dispatch_group_enter(group);
-                    [myDouble methodWithBlock:^{
+                    [myDouble methodWithBlock:^(BOOL){
                         dispatch_group_leave(group);
                     }];
                 });
 
                 dispatch_group_notify(group, queue, ^{
-                    [myDouble methodWithBlock:^{ }];
+                    [myDouble methodWithBlock:^(BOOL){ }];
                 });
 
                 while (!called) {

--- a/Spec/Doubles/SimpleIncrementer.h
+++ b/Spec/Doubles/SimpleIncrementer.h
@@ -14,7 +14,7 @@
 - (void)incrementByInteger:(NSUInteger)number;
 - (void)incrementByABit:(size_t)aBit andABitMore:(NSNumber *)aBitMore;
 - (void)incrementWithException;
-- (void)methodWithBlock:(void(^)())blockArgument;
+- (void)methodWithBlock:(void(^)(BOOL blockReturnValue))blockArgument;
 - (void)methodWithCString:(char *)string;
 - (NSNumber *)methodWithNumber1:(NSNumber *)arg1 andNumber2:(NSNumber *)arg2;
 

--- a/Spec/Doubles/SimpleIncrementer.m
+++ b/Spec/Doubles/SimpleIncrementer.m
@@ -40,7 +40,7 @@
     [[NSException exceptionWithName:NSInternalInconsistencyException reason:@"wibble" userInfo:nil] raise];
 }
 
-- (void)methodWithBlock:(void(^)())blockArgument {
+- (void)methodWithBlock:(void(^)(BOOL blockReturnValue))blockArgument {
 }
 
 - (void)methodWithCString:(char *)string {


### PR DESCRIPTION
Adds `get_argument:at_index:for_last_invocation_of_selector:` to fish arguments from messages sent to doubles. Pass in by reference under spec to then use later. Useful for testing asynchronous methods that take a completion block parameter.

Welcome discussion on method name and whether this belongs better in PCK.
