### PR TITLE
Add a smoke test for the iOS static lib

### DIFF
--- a/CedarSmokeTest/CedarSmokeTest.xcodeproj/project.pbxproj
+++ b/CedarSmokeTest/CedarSmokeTest.xcodeproj/project.pbxproj
@@ -1,0 +1,328 @@
+// !$*UTF8*$!
+{
+	archiveVersion = 1;
+	classes = {
+	};
+	objectVersion = 46;
+	objects = {
+
+/* Begin PBXBuildFile section */
+		AE791C2B184E605100174A3A /* UIKit.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = AECB0A4F184E5BE900F14283 /* UIKit.framework */; };
+		AE791C2C184E605100174A3A /* Foundation.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = AECB0A4B184E5BE900F14283 /* Foundation.framework */; };
+		AE791C2D184E605100174A3A /* CoreGraphics.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = AECB0A4D184E5BE900F14283 /* CoreGraphics.framework */; };
+		AE791C33184E605100174A3A /* InfoPlist.strings in Resources */ = {isa = PBXBuildFile; fileRef = AE791C31184E605100174A3A /* InfoPlist.strings */; };
+		AE791C35184E605100174A3A /* main.m in Sources */ = {isa = PBXBuildFile; fileRef = AE791C34184E605100174A3A /* main.m */; };
+		AE791C3B184E605200174A3A /* ExampleSpec.mm in Sources */ = {isa = PBXBuildFile; fileRef = AE791C3A184E605200174A3A /* ExampleSpec.mm */; };
+		AE791C40184E629F00174A3A /* Cedar-iOS.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = AE791C3F184E629F00174A3A /* Cedar-iOS.framework */; };
+/* End PBXBuildFile section */
+
+/* Begin PBXFileReference section */
+		AE791C2A184E605100174A3A /* CedarSmokeTest.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = CedarSmokeTest.app; sourceTree = BUILT_PRODUCTS_DIR; };
+		AE791C30184E605100174A3A /* CedarSmokeTest-Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = "CedarSmokeTest-Info.plist"; sourceTree = "<group>"; };
+		AE791C32184E605100174A3A /* en */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = en; path = en.lproj/InfoPlist.strings; sourceTree = "<group>"; };
+		AE791C34184E605100174A3A /* main.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = main.m; sourceTree = "<group>"; };
+		AE791C36184E605100174A3A /* CedarSmokeTest-Prefix.pch */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = "CedarSmokeTest-Prefix.pch"; sourceTree = "<group>"; };
+		AE791C37184E605100174A3A /* Rakefile */ = {isa = PBXFileReference; lastKnownFileType = text; path = Rakefile; sourceTree = "<group>"; };
+		AE791C38184E605200174A3A /* Cedar-iOS.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = "Cedar-iOS.framework"; path = "Frameworks/Cedar-iOS.framework"; sourceTree = "<group>"; };
+		AE791C3A184E605200174A3A /* ExampleSpec.mm */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.objcpp; path = ExampleSpec.mm; sourceTree = "<group>"; };
+		AE791C3F184E629F00174A3A /* Cedar-iOS.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = "Cedar-iOS.framework"; path = "../build/Release-iphoneuniversal/Cedar-iOS.framework"; sourceTree = "<group>"; };
+		AECB0A4B184E5BE900F14283 /* Foundation.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = Foundation.framework; path = System/Library/Frameworks/Foundation.framework; sourceTree = SDKROOT; };
+		AECB0A4D184E5BE900F14283 /* CoreGraphics.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = CoreGraphics.framework; path = System/Library/Frameworks/CoreGraphics.framework; sourceTree = SDKROOT; };
+		AECB0A4F184E5BE900F14283 /* UIKit.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = UIKit.framework; path = System/Library/Frameworks/UIKit.framework; sourceTree = SDKROOT; };
+		AECB0A64184E5BE900F14283 /* XCTest.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = XCTest.framework; path = Library/Frameworks/XCTest.framework; sourceTree = DEVELOPER_DIR; };
+/* End PBXFileReference section */
+
+/* Begin PBXFrameworksBuildPhase section */
+		AE791C27184E605100174A3A /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				AE791C40184E629F00174A3A /* Cedar-iOS.framework in Frameworks */,
+				AE791C2D184E605100174A3A /* CoreGraphics.framework in Frameworks */,
+				AE791C2B184E605100174A3A /* UIKit.framework in Frameworks */,
+				AE791C2C184E605100174A3A /* Foundation.framework in Frameworks */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXFrameworksBuildPhase section */
+
+/* Begin PBXGroup section */
+		AE791C2E184E605100174A3A /* CedarSmokeTest */ = {
+			isa = PBXGroup;
+			children = (
+				AE791C37184E605100174A3A /* Rakefile */,
+				AE791C38184E605200174A3A /* Cedar-iOS.framework */,
+				AE791C3A184E605200174A3A /* ExampleSpec.mm */,
+				AE791C2F184E605100174A3A /* Supporting Files */,
+			);
+			path = CedarSmokeTest;
+			sourceTree = "<group>";
+		};
+		AE791C2F184E605100174A3A /* Supporting Files */ = {
+			isa = PBXGroup;
+			children = (
+				AE791C30184E605100174A3A /* CedarSmokeTest-Info.plist */,
+				AE791C31184E605100174A3A /* InfoPlist.strings */,
+				AE791C34184E605100174A3A /* main.m */,
+				AE791C36184E605100174A3A /* CedarSmokeTest-Prefix.pch */,
+			);
+			name = "Supporting Files";
+			sourceTree = "<group>";
+		};
+		AECB0A3F184E5BE900F14283 = {
+			isa = PBXGroup;
+			children = (
+				AE791C2E184E605100174A3A /* CedarSmokeTest */,
+				AECB0A4A184E5BE900F14283 /* Frameworks */,
+				AECB0A49184E5BE900F14283 /* Products */,
+			);
+			sourceTree = "<group>";
+		};
+		AECB0A49184E5BE900F14283 /* Products */ = {
+			isa = PBXGroup;
+			children = (
+				AE791C2A184E605100174A3A /* CedarSmokeTest.app */,
+			);
+			name = Products;
+			sourceTree = "<group>";
+		};
+		AECB0A4A184E5BE900F14283 /* Frameworks */ = {
+			isa = PBXGroup;
+			children = (
+				AE791C3F184E629F00174A3A /* Cedar-iOS.framework */,
+				AECB0A4B184E5BE900F14283 /* Foundation.framework */,
+				AECB0A4D184E5BE900F14283 /* CoreGraphics.framework */,
+				AECB0A4F184E5BE900F14283 /* UIKit.framework */,
+				AECB0A64184E5BE900F14283 /* XCTest.framework */,
+			);
+			name = Frameworks;
+			sourceTree = "<group>";
+		};
+/* End PBXGroup section */
+
+/* Begin PBXNativeTarget section */
+		AE791C29184E605100174A3A /* CedarSmokeTest */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = AE791C3C184E605200174A3A /* Build configuration list for PBXNativeTarget "CedarSmokeTest" */;
+			buildPhases = (
+				AE791C26184E605100174A3A /* Sources */,
+				AE791C27184E605100174A3A /* Frameworks */,
+				AE791C28184E605100174A3A /* Resources */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+			);
+			name = CedarSmokeTest;
+			productName = CedarSmokeTest;
+			productReference = AE791C2A184E605100174A3A /* CedarSmokeTest.app */;
+			productType = "com.apple.product-type.application";
+		};
+/* End PBXNativeTarget section */
+
+/* Begin PBXProject section */
+		AECB0A40184E5BE900F14283 /* Project object */ = {
+			isa = PBXProject;
+			attributes = {
+				LastUpgradeCheck = 0500;
+				ORGANIZATIONNAME = pivotal;
+			};
+			buildConfigurationList = AECB0A43184E5BE900F14283 /* Build configuration list for PBXProject "CedarSmokeTest" */;
+			compatibilityVersion = "Xcode 3.2";
+			developmentRegion = English;
+			hasScannedForEncodings = 0;
+			knownRegions = (
+				en,
+			);
+			mainGroup = AECB0A3F184E5BE900F14283;
+			productRefGroup = AECB0A49184E5BE900F14283 /* Products */;
+			projectDirPath = "";
+			projectRoot = "";
+			targets = (
+				AE791C29184E605100174A3A /* CedarSmokeTest */,
+			);
+		};
+/* End PBXProject section */
+
+/* Begin PBXResourcesBuildPhase section */
+		AE791C28184E605100174A3A /* Resources */ = {
+			isa = PBXResourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				AE791C33184E605100174A3A /* InfoPlist.strings in Resources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXResourcesBuildPhase section */
+
+/* Begin PBXSourcesBuildPhase section */
+		AE791C26184E605100174A3A /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				AE791C35184E605100174A3A /* main.m in Sources */,
+				AE791C3B184E605200174A3A /* ExampleSpec.mm in Sources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXSourcesBuildPhase section */
+
+/* Begin PBXVariantGroup section */
+		AE791C31184E605100174A3A /* InfoPlist.strings */ = {
+			isa = PBXVariantGroup;
+			children = (
+				AE791C32184E605100174A3A /* en */,
+			);
+			name = InfoPlist.strings;
+			sourceTree = "<group>";
+		};
+/* End PBXVariantGroup section */
+
+/* Begin XCBuildConfiguration section */
+		AE791C3D184E605200174A3A /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ARCHS = "$(ARCHS_STANDARD_INCLUDING_64_BIT)";
+				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Developer";
+				FRAMEWORK_SEARCH_PATHS = (
+					"$(inherited)",
+					"$(PROJECT_DIR)/../build/Release-iphoneuniversal",
+				);
+				GCC_PRECOMPILE_PREFIX_HEADER = YES;
+				GCC_PREFIX_HEADER = "CedarSmokeTest/CedarSmokeTest-Prefix.pch";
+				GCC_PREPROCESSOR_DEFINITIONS = (
+					"DEBUG=1",
+					"$(inherited)",
+				);
+				HEADER_SEARCH_PATHS = "$(inherited)";
+				INFOPLIST_FILE = "CedarSmokeTest/CedarSmokeTest-Info.plist";
+				OTHER_LDFLAGS = (
+					"-ObjC",
+					"-all_load",
+					"-lstdc++",
+				);
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				WRAPPER_EXTENSION = app;
+			};
+			name = Debug;
+		};
+		AE791C3E184E605200174A3A /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ARCHS = "$(ARCHS_STANDARD_INCLUDING_64_BIT)";
+				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Developer";
+				FRAMEWORK_SEARCH_PATHS = (
+					"$(inherited)",
+					"$(PROJECT_DIR)/../build/Release-iphoneuniversal",
+				);
+				GCC_PRECOMPILE_PREFIX_HEADER = YES;
+				GCC_PREFIX_HEADER = "CedarSmokeTest/CedarSmokeTest-Prefix.pch";
+				HEADER_SEARCH_PATHS = "$(inherited)";
+				INFOPLIST_FILE = "CedarSmokeTest/CedarSmokeTest-Info.plist";
+				OTHER_CFLAGS = "-DNS_BLOCK_ASSERTIONS=1";
+				OTHER_LDFLAGS = (
+					"-ObjC",
+					"-all_load",
+					"-lstdc++",
+				);
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				WRAPPER_EXTENSION = app;
+			};
+			name = Release;
+		};
+		AECB0A72184E5BE900F14283 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ALWAYS_SEARCH_USER_PATHS = NO;
+				ARCHS = "$(ARCHS_STANDARD_INCLUDING_64_BIT)";
+				CLANG_CXX_LANGUAGE_STANDARD = "gnu++0x";
+				CLANG_CXX_LIBRARY = "libc++";
+				CLANG_ENABLE_MODULES = YES;
+				CLANG_ENABLE_OBJC_ARC = YES;
+				CLANG_WARN_BOOL_CONVERSION = YES;
+				CLANG_WARN_CONSTANT_CONVERSION = YES;
+				CLANG_WARN_DIRECT_OBJC_ISA_USAGE = YES_ERROR;
+				CLANG_WARN_EMPTY_BODY = YES;
+				CLANG_WARN_ENUM_CONVERSION = YES;
+				CLANG_WARN_INT_CONVERSION = YES;
+				CLANG_WARN_OBJC_ROOT_CLASS = YES_ERROR;
+				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
+				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Developer";
+				COPY_PHASE_STRIP = NO;
+				GCC_C_LANGUAGE_STANDARD = gnu99;
+				GCC_DYNAMIC_NO_PIC = NO;
+				GCC_OPTIMIZATION_LEVEL = 0;
+				GCC_PREPROCESSOR_DEFINITIONS = (
+					"DEBUG=1",
+					"$(inherited)",
+				);
+				GCC_SYMBOLS_PRIVATE_EXTERN = NO;
+				GCC_WARN_64_TO_32_BIT_CONVERSION = YES;
+				GCC_WARN_ABOUT_RETURN_TYPE = YES_ERROR;
+				GCC_WARN_UNDECLARED_SELECTOR = YES;
+				GCC_WARN_UNINITIALIZED_AUTOS = YES;
+				GCC_WARN_UNUSED_FUNCTION = YES;
+				GCC_WARN_UNUSED_VARIABLE = YES;
+				IPHONEOS_DEPLOYMENT_TARGET = 7.0;
+				ONLY_ACTIVE_ARCH = YES;
+				SDKROOT = iphoneos;
+			};
+			name = Debug;
+		};
+		AECB0A73184E5BE900F14283 /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ALWAYS_SEARCH_USER_PATHS = NO;
+				ARCHS = "$(ARCHS_STANDARD_INCLUDING_64_BIT)";
+				CLANG_CXX_LANGUAGE_STANDARD = "gnu++0x";
+				CLANG_CXX_LIBRARY = "libc++";
+				CLANG_ENABLE_MODULES = YES;
+				CLANG_ENABLE_OBJC_ARC = YES;
+				CLANG_WARN_BOOL_CONVERSION = YES;
+				CLANG_WARN_CONSTANT_CONVERSION = YES;
+				CLANG_WARN_DIRECT_OBJC_ISA_USAGE = YES_ERROR;
+				CLANG_WARN_EMPTY_BODY = YES;
+				CLANG_WARN_ENUM_CONVERSION = YES;
+				CLANG_WARN_INT_CONVERSION = YES;
+				CLANG_WARN_OBJC_ROOT_CLASS = YES_ERROR;
+				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
+				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Developer";
+				COPY_PHASE_STRIP = YES;
+				ENABLE_NS_ASSERTIONS = NO;
+				GCC_C_LANGUAGE_STANDARD = gnu99;
+				GCC_WARN_64_TO_32_BIT_CONVERSION = YES;
+				GCC_WARN_ABOUT_RETURN_TYPE = YES_ERROR;
+				GCC_WARN_UNDECLARED_SELECTOR = YES;
+				GCC_WARN_UNINITIALIZED_AUTOS = YES;
+				GCC_WARN_UNUSED_FUNCTION = YES;
+				GCC_WARN_UNUSED_VARIABLE = YES;
+				IPHONEOS_DEPLOYMENT_TARGET = 7.0;
+				SDKROOT = iphoneos;
+				VALIDATE_PRODUCT = YES;
+			};
+			name = Release;
+		};
+/* End XCBuildConfiguration section */
+
+/* Begin XCConfigurationList section */
+		AE791C3C184E605200174A3A /* Build configuration list for PBXNativeTarget "CedarSmokeTest" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				AE791C3D184E605200174A3A /* Debug */,
+				AE791C3E184E605200174A3A /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+		};
+		AECB0A43184E5BE900F14283 /* Build configuration list for PBXProject "CedarSmokeTest" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				AECB0A72184E5BE900F14283 /* Debug */,
+				AECB0A73184E5BE900F14283 /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+/* End XCConfigurationList section */
+	};
+	rootObject = AECB0A40184E5BE900F14283 /* Project object */;
+}

--- a/CedarSmokeTest/CedarSmokeTest/CedarSmokeTest-Info.plist
+++ b/CedarSmokeTest/CedarSmokeTest/CedarSmokeTest-Info.plist
@@ -1,0 +1,32 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>CFBundleDevelopmentRegion</key>
+	<string>en</string>
+	<key>CFBundleDisplayName</key>
+	<string>${PRODUCT_NAME}</string>
+	<key>CFBundleExecutable</key>
+	<string>${EXECUTABLE_NAME}</string>
+	<key>CFBundleIdentifier</key>
+	<string>com.yourcompanyname.${PRODUCT_NAME:rfc1034identifier}</string>
+	<key>CFBundleInfoDictionaryVersion</key>
+	<string>6.0</string>
+	<key>CFBundleName</key>
+	<string>${PRODUCT_NAME}</string>
+	<key>CFBundlePackageType</key>
+	<string>APPL</string>
+	<key>CFBundleShortVersionString</key>
+	<string>1.0</string>
+	<key>CFBundleSignature</key>
+	<string>????</string>
+	<key>CFBundleVersion</key>
+	<string>1.0</string>
+	<key>LSRequiresIPhoneOS</key>
+	<true/>
+	<key>UIRequiredDeviceCapabilities</key>
+	<array>
+		<string>armv7</string>
+	</array>
+</dict>
+</plist>

--- a/CedarSmokeTest/CedarSmokeTest/CedarSmokeTest-Prefix.pch
+++ b/CedarSmokeTest/CedarSmokeTest/CedarSmokeTest-Prefix.pch
@@ -1,0 +1,11 @@
+//
+//  Prefix header
+//
+//  The contents of this file are implicitly included at the beginning of every source file.
+//
+
+#ifdef __OBJC__
+    #import <UIKit/UIKit.h>
+    #import <Foundation/Foundation.h>
+    #import <Cedar-iOS/SpecHelper.h>
+#endif

--- a/CedarSmokeTest/CedarSmokeTest/ExampleSpec.mm
+++ b/CedarSmokeTest/CedarSmokeTest/ExampleSpec.mm
@@ -1,0 +1,37 @@
+using namespace Cedar::Matchers;
+using namespace Cedar::Doubles;
+
+SPEC_BEGIN(ExampleSpec)
+
+/* This is not an exhaustive list of usages.
+   For more information, please visit https://github.com/pivotal/cedar */
+
+describe(@"Example specs on NSString", ^{
+
+    it(@"lowercaseString returns a new string with everything in lower case", ^{
+        [@"FOOBar" lowercaseString] should equal(@"foobar");
+    });
+
+    it(@"length returns the number of characters in the string", ^{
+        [@"internationalization" length] should equal(20);
+    });
+
+    describe(@"isEqualToString:", ^{
+        it(@"should return true if the strings are the same", ^{
+            [@"someString" isEqualToString:@"someString"] should be_truthy;
+        });
+
+        it(@"should return false if the strings are not the same", ^{
+            [@"someString" isEqualToString:@"anotherString"] should_not be_truthy;
+        });
+    });
+
+    describe(@"NSMutableString", ^{
+        it(@"should be a kind of NSString", ^{
+            [NSMutableString string] should be_instance_of([NSString class]).or_any_subclass();
+        });
+    });
+});
+
+SPEC_END
+

--- a/CedarSmokeTest/CedarSmokeTest/Rakefile
+++ b/CedarSmokeTest/CedarSmokeTest/Rakefile
@@ -1,0 +1,108 @@
+require 'pathname'
+require 'tmpdir'
+
+module CedarTargetCedarSmokeTest
+  UI_SPECS_TARGET_NAME = "CedarSmokeTest"
+  CONFIGURATION = "Release"
+
+  PROJECT_ROOT = Pathname.new(File.dirname(__FILE__)).parent.to_s
+  BUILD_DIR = File.join(PROJECT_ROOT, "build")
+
+  class << self
+    def in_project_dir
+      original_dir = Dir.pwd
+      Dir.chdir(PROJECT_ROOT)
+
+      yield
+
+      ensure
+      Dir.chdir(original_dir)
+    end
+
+    def deployment_target_sdk_version
+      in_project_dir do
+        `xcodebuild -showBuildSettings -target #{UI_SPECS_TARGET_NAME} | grep IPHONEOS_DEPLOYMENT_TARGET | awk '{print $3 }'`.strip
+      end
+    end
+
+    def deployment_target_sdk_dir
+      @sdk_dir ||= "#{xcode_developer_dir}/Platforms/iPhoneSimulator.platform/Developer/SDKs/iPhoneSimulator#{deployment_target_sdk_version}.sdk"
+    end
+
+    # Xcode 4.3 stores its /Developer inside /Applications/Xcode.app, Xcode 4.2 stored it in /Developer
+    def xcode_developer_dir
+      `xcode-select -print-path`.strip
+    end
+
+    def build_dir(effective_platform_name)
+      File.join(BUILD_DIR, CONFIGURATION + effective_platform_name)
+    end
+
+    def system_or_exit(cmd, stdout = nil)
+      puts "Executing #{cmd}"
+      cmd += " >#{stdout}" if stdout
+      system(cmd) or raise "******** Build failed ********"
+    end
+
+    def with_env_vars(env_vars)
+      old_values = {}
+      env_vars.each do |key,new_value|
+        old_values[key] = ENV[key]
+        ENV[key] = new_value
+      end
+
+      yield
+
+      env_vars.each_key do |key|
+        ENV[key] = old_values[key]
+      end
+    end
+
+    def output_file(target)
+      output_dir = if ENV['IS_CI_BOX']
+        ENV['CC_BUILD_ARTIFACTS']
+      else
+        Dir.mkdir(BUILD_DIR) unless File.exists?(BUILD_DIR)
+        BUILD_DIR
+      end
+
+      output_file = File.join(output_dir, "#{target}.output")
+      puts "Output: #{output_file}"
+      output_file
+    end
+
+    def kill_simulator
+      system %Q[killall -m -KILL "gdb"]
+      system %Q[killall -m -KILL "otest"]
+      system %Q[killall -m -KILL "iPhone Simulator"]
+    end
+  end
+end
+
+desc "Clean build directory"
+task :clean_CedarSmokeTest do
+  CedarTargetCedarSmokeTest.system_or_exit "rm -rf #{CedarTargetCedarSmokeTest::BUILD_DIR}/*", CedarTargetCedarSmokeTest.output_file("clean")
+end
+
+desc "Build CedarSmokeTest"
+task :build_CedarSmokeTest => :clean_CedarSmokeTest do
+  CedarTargetCedarSmokeTest.kill_simulator
+  CedarTargetCedarSmokeTest.system_or_exit "pushd #{CedarTargetCedarSmokeTest::PROJECT_ROOT} && xcodebuild -target #{CedarTargetCedarSmokeTest::UI_SPECS_TARGET_NAME} -configuration #{CedarTargetCedarSmokeTest::CONFIGURATION} -sdk iphonesimulator build ARCHS=i386 && popd", CedarTargetCedarSmokeTest.output_file("CedarSmokeTest")
+end
+
+desc "Run CedarSmokeTest"
+task :CedarSmokeTest => :build_CedarSmokeTest do
+  env_vars = {
+    "DYLD_ROOT_PATH" => CedarTargetCedarSmokeTest.deployment_target_sdk_dir,
+    "IPHONE_SIMULATOR_ROOT" => CedarTargetCedarSmokeTest.deployment_target_sdk_dir,
+    "CFFIXED_USER_HOME" => Dir.tmpdir,
+    "CEDAR_HEADLESS_SPECS" => "1",
+    "CEDAR_REPORTER_CLASS" => "CDRColorizedReporter"
+  }
+
+  app_path = File.join(CedarTargetCedarSmokeTest.build_dir("-iphonesimulator"), "#{CedarTargetCedarSmokeTest::UI_SPECS_TARGET_NAME}.app")
+
+  CedarTargetCedarSmokeTest.with_env_vars(env_vars) do
+    CedarTargetCedarSmokeTest.system_or_exit "#{File.join(CedarTargetCedarSmokeTest.build_dir("-iphonesimulator"), "#{CedarTargetCedarSmokeTest::UI_SPECS_TARGET_NAME}.app", CedarTargetCedarSmokeTest::UI_SPECS_TARGET_NAME)} -RegisterForSystemEvents";
+  end
+end

--- a/CedarSmokeTest/CedarSmokeTest/en.lproj/InfoPlist.strings
+++ b/CedarSmokeTest/CedarSmokeTest/en.lproj/InfoPlist.strings
@@ -1,0 +1,2 @@
+/* Localized versions of Info.plist keys */
+

--- a/CedarSmokeTest/CedarSmokeTest/main.m
+++ b/CedarSmokeTest/CedarSmokeTest/main.m
@@ -1,0 +1,18 @@
+//
+//  main.m
+//  CedarSmokeTest
+//
+//  Created by pivotal on 12/3/13.
+//  Copyright (c) 2013 pivotal. All rights reserved.
+//
+
+#import <UIKit/UIKit.h>
+
+#import <Cedar-iOS/Cedar-iOS.h>
+
+int main(int argc, const char * argv[])
+{
+    @autoreleasepool {
+        return UIApplicationMain(argc, argv, nil, @"CedarApplicationDelegate");
+    }
+}


### PR DESCRIPTION
We tried to implement this as a separate target inside the existing
Cedar project, but found that XCode 5 has multiple problems adding a
new target for iOS to this project. I suspect it has something to do
with the project having been upgraded from earlier versions of xcode.

It would obviously be best if this was a separate target, but Jesse and
I spent a long time hitting our heads against a wall trying to make that
work, and it seemed like adding this as a separate, standalone project
was the most valuable use of our time on this task.

We tested locally that when a header isn't included in the iOS staticlib
target that the rake task will return a non-zero exit code, so this
should make accepting PRs that run on Travis a lot easier.

NB: this is going to fail on Travis because we branched at a ref where
ConformTo.h is not included in the framework target. We considered rebasing
to show that it would go green, but we thought the fact that it does go red 
in this case was valuable information to share.
