### PR TITLE
Add a be_falsy matcher to complement be_truthy

### DIFF
--- a/Cedar.xcodeproj/project.pbxproj
+++ b/Cedar.xcodeproj/project.pbxproj
@@ -188,6 +188,10 @@
 		AE3E8F37184FEEE000633740 /* ObjectWithCollections.h in Headers */ = {isa = PBXBuildFile; fileRef = AE3E8F35184FEEE000633740 /* ObjectWithCollections.h */; };
 		AE3E8F39184FEEE900633740 /* ObjectWithCollections.m in Sources */ = {isa = PBXBuildFile; fileRef = AE3E8F36184FEEE000633740 /* ObjectWithCollections.m */; };
 		AE3E8F3A184FEEEB00633740 /* ObjectWithCollections.m in Sources */ = {isa = PBXBuildFile; fileRef = AE3E8F36184FEEE000633740 /* ObjectWithCollections.m */; };
+		AE4A9458187F7D8F008566F5 /* BeFalsy.h in Headers */ = {isa = PBXBuildFile; fileRef = AE4A9457187F7D8F008566F5 /* BeFalsy.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		AE4A9459187F7D8F008566F5 /* BeFalsy.h in Copy headers to framework */ = {isa = PBXBuildFile; fileRef = AE4A9457187F7D8F008566F5 /* BeFalsy.h */; };
+		AE4A945B187F7E52008566F5 /* BeFalsySpec.mm in Sources */ = {isa = PBXBuildFile; fileRef = AE4A945A187F7E52008566F5 /* BeFalsySpec.mm */; };
+		AE4A945C187F7E52008566F5 /* BeFalsySpec.mm in Sources */ = {isa = PBXBuildFile; fileRef = AE4A945A187F7E52008566F5 /* BeFalsySpec.mm */; };
 		AE5218D3175979CA00A656BC /* ObjectWithWeakDelegate.m in Sources */ = {isa = PBXBuildFile; fileRef = AE5218D2175979CA00A656BC /* ObjectWithWeakDelegate.m */; settings = {COMPILER_FLAGS = "-fobjc-arc"; }; };
 		AE5218D5175979D900A656BC /* WeakReferenceCompatibilitySpec.mm in Sources */ = {isa = PBXBuildFile; fileRef = AE5218D4175979D900A656BC /* WeakReferenceCompatibilitySpec.mm */; };
 		AE53B67E17E7BCAA00D83D5E /* CDRClassFakeSpec.mm in Sources */ = {isa = PBXBuildFile; fileRef = AE9AA67F15AB748E00617E1A /* CDRClassFakeSpec.mm */; };
@@ -524,6 +528,7 @@
 				AEF33018145B6222002F93BB /* BeLessThan.h in Copy headers to framework */,
 				AEF33022145B69DE002F93BB /* BeLTE.h in Copy headers to framework */,
 				AEB45A921496C8D800845D09 /* RaiseException.h in Copy headers to framework */,
+				AE4A9459187F7D8F008566F5 /* BeFalsy.h in Copy headers to framework */,
 				6628FC8914C4DBA70016652A /* CedarDoubles.h in Copy headers to framework */,
 				6628FC9A14C4DD440016652A /* CDRSpy.h in Copy headers to framework */,
 				6628FCA114C503530016652A /* Cedar-iOS.h in Copy headers to framework */,
@@ -656,6 +661,8 @@
 		AE36AC6415B5CA6E00EB6C51 /* CedarDouble.mm */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.objcpp; path = CedarDouble.mm; sourceTree = "<group>"; };
 		AE3E8F35184FEEE000633740 /* ObjectWithCollections.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = ObjectWithCollections.h; sourceTree = "<group>"; };
 		AE3E8F36184FEEE000633740 /* ObjectWithCollections.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = ObjectWithCollections.m; sourceTree = "<group>"; };
+		AE4A9457187F7D8F008566F5 /* BeFalsy.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = BeFalsy.h; sourceTree = "<group>"; };
+		AE4A945A187F7E52008566F5 /* BeFalsySpec.mm */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.objcpp; path = BeFalsySpec.mm; sourceTree = "<group>"; };
 		AE5218D1175979CA00A656BC /* ObjectWithWeakDelegate.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = ObjectWithWeakDelegate.h; sourceTree = "<group>"; };
 		AE5218D2175979CA00A656BC /* ObjectWithWeakDelegate.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = ObjectWithWeakDelegate.m; sourceTree = "<group>"; };
 		AE5218D4175979D900A656BC /* WeakReferenceCompatibilitySpec.mm */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.objcpp; path = WeakReferenceCompatibilitySpec.mm; sourceTree = "<group>"; };
@@ -1423,6 +1430,7 @@
 			children = (
 				AEF72FFB13ECC21E00786282 /* Base.h */,
 				AEF72FFC13ECC21E00786282 /* BeCloseTo.h */,
+				AE4A9457187F7D8F008566F5 /* BeFalsy.h */,
 				AEF32FF1145A2D79002F93BB /* BeGreaterThan.h */,
 				AEF3300B145B4F75002F93BB /* BeGTE.h */,
 				AEF72FFD13ECC21E00786282 /* BeInstanceOf.h */,
@@ -1444,6 +1452,7 @@
 			isa = PBXGroup;
 			children = (
 				AEF7301413ECC4AE00786282 /* BeCloseToSpec.mm */,
+				AE4A945A187F7E52008566F5 /* BeFalsySpec.mm */,
 				AE6F3F331458D7C100C98F1E /* BeGreaterThanSpec.mm */,
 				AEF33008145B4E3B002F93BB /* BeGTESpec.mm */,
 				AEF7301513ECC4AE00786282 /* BeInstanceOfSpec.mm */,
@@ -1549,6 +1558,7 @@
 				AE18A7CB13F453CC00C8872C /* BeCloseTo.h in Headers */,
 				AE18A7CC13F453CC00C8872C /* BeInstanceOf.h in Headers */,
 				AE18A7CD13F453CC00C8872C /* BeNil.h in Headers */,
+				AE4A9458187F7D8F008566F5 /* BeFalsy.h in Headers */,
 				AE18A7CE13F453CC00C8872C /* BeSameInstanceAs.h in Headers */,
 				2234907D18009DA6001C8E8D /* CDRHooks.h in Headers */,
 				AE3E8F37184FEEE000633740 /* ObjectWithCollections.h in Headers */,
@@ -2081,6 +2091,7 @@
 				AEF7301B13ECC4AE00786282 /* BeCloseToSpec.mm in Sources */,
 				AE53B68417E7CD8D00D83D5E /* ObjectWithWeakDelegate.m in Sources */,
 				AE80788D183C71950078C608 /* ArgumentReleaser.m in Sources */,
+				AE4A945B187F7E52008566F5 /* BeFalsySpec.mm in Sources */,
 				AEF7301D13ECC4AE00786282 /* BeInstanceOfSpec.mm in Sources */,
 				AE807890183C71950078C608 /* SimpleIncrementer.m in Sources */,
 				AEF7301F13ECC4AE00786282 /* BeNilSpec.mm in Sources */,
@@ -2212,6 +2223,7 @@
 				AEF3301F145B68D7002F93BB /* BeLTESpec.mm in Sources */,
 				966E74EE145A6CA0002E8D49 /* ShouldSyntaxSpec.mm in Sources */,
 				AEBB92631496C1F000EEBD59 /* RaiseExceptionSpec.mm in Sources */,
+				AE4A945C187F7E52008566F5 /* BeFalsySpec.mm in Sources */,
 				AE02E82A184EF2A300414F19 /* CDRExampleGroupSpec.mm in Sources */,
 				492951E51482FF6300FA8916 /* CDRJUnitXMLReporterSpec.mm in Sources */,
 				AE53B68017E7BCAA00D83D5E /* CDRSpySpec.mm in Sources */,

--- a/Source/Headers/Matchers/Base/BeFalsy.h
+++ b/Source/Headers/Matchers/Base/BeFalsy.h
@@ -1,0 +1,31 @@
+#import <Foundation/Foundation.h>
+#import "Base.h"
+
+namespace Cedar { namespace Matchers {
+    class BeFalsy : public Base<> {
+    private:
+        BeFalsy & operator=(const BeFalsy &);
+
+    public:
+        inline BeFalsy() : Base<>() {}
+        inline ~BeFalsy() {}
+        // Allow default copy ctor.
+
+        inline const BeFalsy & operator()() const { return *this; }
+
+        template<typename U>
+        bool matches(const U &) const;
+
+    protected:
+        inline /*virtual*/ NSString * failure_message_end() const { return @"evaluate to false"; }
+    };
+
+    static const BeFalsy be_falsy = BeFalsy();
+
+#pragma mark Generic
+    template<typename U>
+    bool BeFalsy::matches(const U & actualValue) const {
+        return !actualValue;
+    }
+
+}}

--- a/Source/Headers/Matchers/CedarMatchers.h
+++ b/Source/Headers/Matchers/CedarMatchers.h
@@ -1,6 +1,7 @@
 // Base
 #import "Equal.h"
 #import "BeTruthy.h"
+#import "BeFalsy.h"
 #import "BeNil.h"
 #import "BeCloseTo.h"
 #import "BeSameInstanceAs.h"

--- a/Spec/Matchers/Base/BeFalsySpec.mm
+++ b/Spec/Matchers/Base/BeFalsySpec.mm
@@ -1,0 +1,106 @@
+#if TARGET_OS_IPHONE
+#import <Cedar/SpecHelper.h>
+#else
+#import <Cedar/SpecHelper.h>
+#endif
+
+extern "C" {
+#import "ExpectFailureWithMessage.h"
+}
+
+using namespace Cedar::Matchers;
+using namespace Cedar::Doubles;
+
+SPEC_BEGIN(BeFalsySpec)
+
+describe(@"be_falsy matcher", ^{
+    describe(@"when the value is a built-in type", ^{
+        __block BOOL value;
+
+        describe(@"which evaluates to false", ^{
+            beforeEach(^{
+                value = NO;
+            });
+
+            describe(@"positive match", ^{
+                it(@"should pass", ^{
+                    value should be_falsy;
+                });
+            });
+
+            describe(@"negative match", ^{
+                it(@"should fail with a sensible failure message", ^{
+                    expectFailureWithMessage(@"Expected <NO> to not evaluate to false", ^{
+                        value should_not be_falsy;
+                    });
+                });
+            });
+        });
+
+        describe(@"which evaluates to true", ^{
+            beforeEach(^{
+                value = YES;
+            });
+
+            describe(@"positive match", ^{
+                it(@"should fail with a sensible failure message", ^{
+                    expectFailureWithMessage(@"Expected <YES> to evaluate to false", ^{
+                        value should be_falsy;
+                    });
+                });
+            });
+
+            describe(@"negative match", ^{
+                it(@"should should pass", ^{
+                    value should_not be_falsy;
+                });
+            });
+        });
+    });
+
+    describe(@"when the value is an id", ^{
+        __block id value;
+
+        describe(@"which evaluates to false", ^{
+            beforeEach(^{
+                value = nil;
+            });
+
+            describe(@"positive match", ^{
+                it(@"should should pass", ^{
+                    value should be_falsy;
+                });
+            });
+
+            describe(@"negative match", ^{
+                it(@"should fail with a sensible failure message", ^{
+                    expectFailureWithMessage(@"Expected <(null)> to not evaluate to false", ^{
+                        value should_not be_falsy;
+                    });
+                });
+            });
+        });
+
+        describe(@"which evaluates to true", ^{
+            beforeEach(^{
+                value = @"cat";
+            });
+
+            describe(@"positive match", ^{
+                it(@"should fail with a sensible failure message", ^{
+                    expectFailureWithMessage(@"Expected <cat> to evaluate to false", ^{
+                        value should be_falsy;
+                    });
+                });
+            });
+
+            describe(@"negative match", ^{
+                it(@"should should pass", ^{
+                    value should_not be_falsy;
+                });
+            });
+        });
+    });
+});
+
+SPEC_END


### PR DESCRIPTION
I think it would be convenient to have a be_falsy matcher so that you don't have to write 'should_not be_truthy' in your specs.
