### PR TITLE
CDRSpies will give up spying on internal methods after seeing the same method names being called recursively

### DIFF
--- a/Source/Doubles/CDRSpy.mm
+++ b/Source/Doubles/CDRSpy.mm
@@ -103,8 +103,13 @@
         } else {
             CDRSpyInfo *spyInfo = [CDRSpyInfo spyInfoForObject:self];
             IMP privateImp = [spyInfo impForSelector:selector];
-            if (privateImp) {
-                [invocation invokeUsingIMP:privateImp];
+            if (privateImp && ![spyInfo isInvocationRepeatedInCallStack:invocation]) {
+                [spyInfo addToCallStack:invocation];
+                @try {
+                    [invocation invokeUsingIMP:privateImp];
+                } @finally {
+                    [spyInfo popCallStack];
+                }
             } else {
                 __block id that = self;
                 [self as_spied_class:^{

--- a/Source/Headers/Doubles/CDRSpyInfo.h
+++ b/Source/Headers/Doubles/CDRSpyInfo.h
@@ -8,6 +8,7 @@
 @property (nonatomic, assign) Class spiedClass;
 @property (nonatomic, assign) id originalObject;
 @property (nonatomic, retain) CedarDoubleImpl *cedarDouble;
+@property (nonatomic, retain) NSMutableArray *callStack;
 
 + (void)storeSpyInfoForObject:(id)object;
 + (BOOL)clearSpyInfoForObject:(id)object;
@@ -17,5 +18,9 @@
 + (Class)publicClassForObject:(id)object;
 
 - (IMP)impForSelector:(SEL)selector;
+
+- (BOOL)isInvocationRepeatedInCallStack:(NSInvocation *)invocation;
+- (void)addToCallStack:(NSInvocation *)invocation;
+- (void)popCallStack;
 
 @end


### PR DESCRIPTION
See #153.

NSTimer internally checks for its class and calls either -[fireDate] or __cffiredate. This either means that NSTimer is class cluster or some NSTimer-specific object_getClass() checks that make sure the class is correct. If not, they seem to invoke the other method. Those two methods recursively trampoline until a stack overflow occurs.

Alternatively, we can choose to not to special-case this scenario and treat NSTimers as un-spyable.
