### PR TITLE
[#20219539] Empty describe blocks should appear in results as pending

### DIFF
--- a/Source/CDRSpec.m
+++ b/Source/CDRSpec.m
@@ -28,6 +28,10 @@ CDRExampleGroup * describe(NSString *text, CDRSpecBlock block) {
         [parentGroup add:group];
         currentSpec.currentGroup = group;
         block();
+        if ([group.examples count] == 0) {
+            block = placeholderPendingTestBlock;
+            block();
+        }
         currentSpec.currentGroup = parentGroup;
     } else {
         group = describe(text, placeholderPendingTestBlock);

--- a/Spec/SpecSpec.mm
+++ b/Spec/SpecSpec.mm
@@ -86,6 +86,9 @@ describe(@"Spec", ^{
     context(@"contexted specs should be pending", PENDING);
     context(@"contexted specs should also be pending", nil);
     xcontext(@"xcontexted specs should be pending", ^{});
+
+    describe(@"empty describe blocks should be pending", ^{});
+    context(@"empty context blocks should be pending", ^{});
 });
 
 describe(@"The spec failure exception", ^{


### PR DESCRIPTION
This change adds the ability to evaluate a block, check if any examples are present and, if not, reassign the block to the pending test block and execute it again. Net effect is that blocks with no content are treated as pending as per the story request.

Note: There are currently two tests in the suite that are now reported as pending that were not before, they are:

1) "a describe block that tries to include a shared example group that doesn't exist"
2) "The spec failure exception"
#1 must be the case if we are to consider empty blocks pending since it is effectively empty since the shared example does not really exist.
#2 is currently commented out in the cedar specs, has been for some time now, and should probably be removed or uncommented and fixed.
