### PR TITLE
add inherited to other linker flags

### DIFF
--- a/CodeSnippetsAndTemplates/Templates/Project Templates/Cedar/iOS Cedar Spec Suite.xctemplate/TemplateInfo.plist
+++ b/CodeSnippetsAndTemplates/Templates/Project Templates/Cedar/iOS Cedar Spec Suite.xctemplate/TemplateInfo.plist
@@ -134,7 +134,7 @@
 			<key>SharedSettings</key>
 			<dict>
 				<key>OTHER_LDFLAGS</key>
-				<string>-ObjC -all_load -lstdc++</string>
+				<string>$(inherited) -ObjC -all_load -lstdc++</string>
 				<key>CODE_SIGN_IDENTITY[sdk=iphoneos*]</key>
 				<string>iPhone Developer</string>
 			</dict>


### PR DESCRIPTION
I'm currently working on [the PCK story for improving the cocoapods experience](https://www.pivotaltracker.com/story/show/66202792) and I noticed that, when a user uses pods to link against the PCK Foundation library the xml2 dependancy gets lost in the process since the current Cedar template does not honor inherited linker flags.

This PR is to:

1) raise this issue
2) propose a solution (add $inherited) for iOS specs
3) get feedback about how this may be better solved (this is the simplest thing I can think of)

The end goal here is to be able to add cedar spec targets to a project in such a way that they play better with libraries added with cocoapods (i.e. PCK) that have their own static lib dependencies - the user should be able to add a pod without having to manually link against xml2 (or any other required lib).
