### PR TITLE
Use NSInvocation to quit with status code

### DIFF
--- a/Source/iPhone/CedarApplicationDelegate.m
+++ b/Source/iPhone/CedarApplicationDelegate.m
@@ -25,9 +25,13 @@ int runSpecsWithinUIApplication() {
 
 void exitWithStatusFromUIApplication(int status) {
     UIApplication *application = [UIApplication sharedApplication];
-    SEL _terminateWithStatusSelector = NSSelectorFromString(@"_terminateWithStatus:");
-    if ([application respondsToSelector:_terminateWithStatusSelector]) {
-        [application performSelector:_terminateWithStatusSelector withObject:(id)status];
+    SEL terminateWithStatusSelector = NSSelectorFromString(@"_terminateWithStatus:");
+    if ([application respondsToSelector:terminateWithStatusSelector]) {
+        NSMethodSignature *signature = [application methodSignatureForSelector:terminateWithStatusSelector];
+        NSInvocation *invocation = [NSInvocation invocationWithMethodSignature:signature];
+        invocation.selector = terminateWithStatusSelector;
+        [invocation setArgument:&status atIndex:2];
+        [invocation invokeWithTarget:application];
     } else {
         exit(status);
     }


### PR DESCRIPTION
Removes build warning caused by sending non-pointer type as parameter to performSelector:withObject: for _terminateWithStatus call. Rather than trying to cast the integer to a pointer type, uses NSInvocation to invoke the method.

Fixes issue https://github.com/pivotal/cedar/issues/191.
