### PR TITLE
Suppress -Wcompare-distinct-pointer-types in BeSameInstanceAs

### DIFF
--- a/Source/Headers/Matchers/Base/BeSameInstanceAs.h
+++ b/Source/Headers/Matchers/Base/BeSameInstanceAs.h
@@ -83,7 +83,10 @@ namespace Cedar { namespace Matchers {
 
     template<typename T> template<typename U>
     bool BeSameInstanceAs<T>::matches(U * const & actualValue) const {
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wcompare-distinct-pointer-types"
         return actualValue == expectedValue_;
+#pragma clang diagnostic pop
     }
 
 }}


### PR DESCRIPTION
This is helpful when used with Xcode 5.1, when the compared types have no common ancestry, e.g. UIViewController\* vs. id<UITableViewDelegate>
