### PR TITLE
Adds compare equals support for CGVector

### DIFF
--- a/Source/Headers/Matchers/UIKit/UIGeometryCompareEqual.h
+++ b/Source/Headers/Matchers/UIKit/UIGeometryCompareEqual.h
@@ -20,6 +20,13 @@ namespace Cedar { namespace Matchers { namespace Comparators {
     }
 
     template<typename U>
+    bool compare_equal(CGVector const actualValue, const U & expectedValue) {
+        CGPoint pointActualValue = CGPointMake(actualValue.dx, actualValue.dy);
+        CGPoint pointExpectedValue = CGPointMake(expectedValue.dx, expectedValue.dy);
+        return CGPointEqualToPoint(pointActualValue, pointExpectedValue);
+    }
+
+    template<typename U>
     bool compare_equal(UIEdgeInsets const actualValue, const U & expectedValue) {
         return UIEdgeInsetsEqualToEdgeInsets(actualValue, expectedValue);
     }

--- a/Source/Headers/Matchers/UIKit/UIGeometryStringifiers.h
+++ b/Source/Headers/Matchers/UIKit/UIGeometryStringifiers.h
@@ -14,6 +14,11 @@ namespace Cedar { namespace Matchers { namespace Stringifiers {
         return NSStringFromCGPoint(value);
     }
 
+    inline NSString * string_for(const CGVector value) {
+        CGPoint pointValue = CGPointMake(value.dx, value.dy);
+        return NSStringFromCGPoint(pointValue);
+    }
+
     inline NSString * string_for(const UIEdgeInsets value) {
         return NSStringFromUIEdgeInsets(value);
     }

--- a/Spec/Matchers/UI/UIKitEqualSpec.mm
+++ b/Spec/Matchers/UI/UIKitEqualSpec.mm
@@ -67,6 +67,24 @@ describe(@"CoreGraphics and UIGeometry struct comparisons", ^{
         });
     });
 
+    describe(@"comparing CGVectors", ^{
+        it(@"should be possible", ^{
+            CGVector thisVector = CGVectorMake(10, 20);
+            CGVector thatVector = CGVectorMake(10, 20);
+
+            thisVector should equal(thatVector);
+        });
+
+        it(@"should fail with a reasonable message", ^{
+            expectFailureWithMessage(@"Expected <{10, 20}> to equal <{11, 22}>", ^{
+                CGVector thisVector = CGVectorMake(10, 20);
+                CGVector thatVector = CGVectorMake(11, 22);
+
+                thisVector should equal(thatVector);
+            });
+        });
+    });
+
     describe(@"comparing UIEdgeInsets", ^{
         it(@"should be possible", ^{
             UIEdgeInsets theseInsets = UIEdgeInsetsMake(10, 20, 30, 40);


### PR DESCRIPTION
This adds compare equals support for CGVectors. Uses NSStringFromCGPoint and CGPointEqualToPoint since no equivalents currently exist for CGVector.
