### PR TITLE
Add workaround for a crash occurring when running the Specs target on Mo...

### DIFF
--- a/Cedar.xcodeproj/project.pbxproj
+++ b/Cedar.xcodeproj/project.pbxproj
@@ -2585,6 +2585,7 @@
 				GCC_PRECOMPILE_PREFIX_HEADER = YES;
 				GCC_PREFIX_HEADER = "";
 				INSTALL_PATH = /usr/local/bin;
+				MACOSX_DEPLOYMENT_TARGET = "";
 				ONLY_ACTIVE_ARCH = YES;
 				OTHER_LDFLAGS = (
 					"-framework",
@@ -2608,6 +2609,7 @@
 				GCC_PRECOMPILE_PREFIX_HEADER = YES;
 				GCC_PREFIX_HEADER = "";
 				INSTALL_PATH = /usr/local/bin;
+				MACOSX_DEPLOYMENT_TARGET = "";
 				ONLY_ACTIVE_ARCH = YES;
 				OTHER_LDFLAGS = (
 					"-framework",

--- a/Source/CDRFunctions.m
+++ b/Source/CDRFunctions.m
@@ -35,7 +35,9 @@ NSArray *CDRSelectClasses(BOOL (^classSelectionPredicate)(Class class)) {
         Class class = classes[i];
 
         if (classSelectionPredicate(class)) {
+            [class retain];
             [selectedClasses addObject:class];
+            [class release];
         }
     }
     return selectedClasses;
@@ -85,12 +87,13 @@ NSArray *CDRReporterClassesFromEnv(const char *defaultReporterClassName) {
 
     NSMutableArray *reporterClasses = [NSMutableArray arrayWithCapacity:[reporterClassNames count]];
     for (NSString *reporterClassName in reporterClassNames) {
-        Class reporterClass = NSClassFromString(reporterClassName);
+        Class reporterClass = [NSClassFromString(reporterClassName) retain];
         if (!reporterClass) {
             printf("***** The specified reporter class \"%s\" does not exist. *****\n", [reporterClassName cStringUsingEncoding:NSUTF8StringEncoding]);
             return nil;
         }
         [reporterClasses addObject:reporterClass];
+        [reporterClass release];
     }
     return reporterClasses;
 }


### PR DESCRIPTION
...untain Lion [#68120746]

This fixes the crash when running specs, as reported in the linked bug in Tracker. However the root bug in Apple's code which causes this issue does still prevent rake from passing when it is run on Mountain Lion because the test runner crashes while trying to load the Specs target's test bundle (OCUnitAppLogicTests). Nonetheless, this patch does seem to allow running the Specs target itself, which may be sufficient for some people's purposes.

Note that rake runs just fine under Mavericks, in any case.
