### PR TITLE
Stub and_do_block with a block taking the same arguments as the method

### DIFF
--- a/Cedar.xcodeproj/project.pbxproj
+++ b/Cedar.xcodeproj/project.pbxproj
@@ -74,6 +74,8 @@
 		228F3FA717E3ECD10000C8AF /* CDRSpyiOSSpec.mm in Sources */ = {isa = PBXBuildFile; fileRef = 228F3FA617E3ECD10000C8AF /* CDRSpyiOSSpec.mm */; };
 		22B6A22715B7ACF800960ADE /* InvocationMatcher.h in Copy headers to framework */ = {isa = PBXBuildFile; fileRef = AE597B4015B0638B00EEF305 /* InvocationMatcher.h */; };
 		22FB7B4416ACBB3A00012D69 /* HeadlessSimulatorWorkaround.m in Sources */ = {isa = PBXBuildFile; fileRef = 22FB7B4316ACBB3A00012D69 /* HeadlessSimulatorWorkaround.m */; };
+		34ADE41818F23C8E00BD1E99 /* NSMethodSignature+Cedar.m in Sources */ = {isa = PBXBuildFile; fileRef = 34ADE41618F23C8E00BD1E99 /* NSMethodSignature+Cedar.m */; };
+		34ADE41918F23E6B00BD1E99 /* NSMethodSignature+Cedar.m in Sources */ = {isa = PBXBuildFile; fileRef = 34ADE41618F23C8E00BD1E99 /* NSMethodSignature+Cedar.m */; };
 		42064466139B44EC00C85605 /* CDRTeamCityReporter.h in Headers */ = {isa = PBXBuildFile; fileRef = 42064465139B44EC00C85605 /* CDRTeamCityReporter.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		42064467139B44EC00C85605 /* CDRTeamCityReporter.h in Headers */ = {isa = PBXBuildFile; fileRef = 42064465139B44EC00C85605 /* CDRTeamCityReporter.h */; };
 		4206446A139B44F600C85605 /* CDRTeamCityReporter.m in Sources */ = {isa = PBXBuildFile; fileRef = 42064469139B44F600C85605 /* CDRTeamCityReporter.m */; };
@@ -612,6 +614,9 @@
 		228F3FA617E3ECD10000C8AF /* CDRSpyiOSSpec.mm */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.objcpp; path = CDRSpyiOSSpec.mm; sourceTree = "<group>"; };
 		22FB7B4016ACBA5900012D69 /* HeadlessSimulatorWorkaround.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = HeadlessSimulatorWorkaround.h; sourceTree = "<group>"; };
 		22FB7B4316ACBB3A00012D69 /* HeadlessSimulatorWorkaround.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = HeadlessSimulatorWorkaround.m; sourceTree = "<group>"; };
+		3460488818F26F5400BC93B6 /* NSMethodSignature+Cedar.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = "NSMethodSignature+Cedar.h"; sourceTree = "<group>"; };
+		3460489318F2DBBF00BC93B6 /* CDRBlockHelper.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = CDRBlockHelper.h; sourceTree = "<group>"; };
+		34ADE41618F23C8E00BD1E99 /* NSMethodSignature+Cedar.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = "NSMethodSignature+Cedar.m"; sourceTree = "<group>"; };
 		42064465139B44EC00C85605 /* CDRTeamCityReporter.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = CDRTeamCityReporter.h; sourceTree = "<group>"; };
 		42064469139B44F600C85605 /* CDRTeamCityReporter.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = CDRTeamCityReporter.m; sourceTree = "<group>"; };
 		4523F16026FC3298AB3B00BE /* ExampleWithPublicRunDates.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = ExampleWithPublicRunDates.h; sourceTree = "<group>"; };
@@ -1236,6 +1241,7 @@
 		AE51227717314E27000FFF73 /* Extensions */ = {
 			isa = PBXGroup;
 			children = (
+				3460488818F26F5400BC93B6 /* NSMethodSignature+Cedar.h */,
 				AE7F1704172730B000E1146D /* NSInvocation+Cedar.h */,
 			);
 			path = Extensions;
@@ -1245,6 +1251,7 @@
 			isa = PBXGroup;
 			children = (
 				AE7F1705172730B000E1146D /* NSInvocation+Cedar.m */,
+				34ADE41618F23C8E00BD1E99 /* NSMethodSignature+Cedar.m */,
 			);
 			path = Extensions;
 			sourceTree = "<group>";
@@ -1381,6 +1388,7 @@
 				969B6F95160F1FEC00C7C792 /* CDRSymbolicator.h */,
 				AEEE1FD311DC27B800029872 /* Cedar.h */,
 				AEEE1FDB11DC27B800029872 /* SpecHelper.h */,
+				3460489318F2DBBF00BC93B6 /* CDRBlockHelper.h */,
 			);
 			path = Headers;
 			sourceTree = "<group>";
@@ -2137,6 +2145,7 @@
 				9637852B1491D6D40059C9F6 /* CDROTestHelper.m in Sources */,
 				492951E01481AAFA00FA8916 /* CDRJUnitXMLReporter.m in Sources */,
 				6628FC9C14C4DEC50016652A /* CDRSpy.mm in Sources */,
+				34ADE41818F23C8E00BD1E99 /* NSMethodSignature+Cedar.m in Sources */,
 				1FF4497D18A0B37A00AF94B0 /* AnyArgument.mm in Sources */,
 				AE9AA68715AB7E0900617E1A /* CDRClassFake.mm in Sources */,
 				AE9AA6DE15AE0BE200617E1A /* CedarDoubleImpl.mm in Sources */,
@@ -2257,6 +2266,7 @@
 				AE74907215B486CD008EA127 /* CDRFake.mm in Sources */,
 				AE74907715B493C4008EA127 /* CDRProtocolFake.mm in Sources */,
 				AE36AC6615B5CA6E00EB6C51 /* CedarDouble.mm in Sources */,
+				34ADE41918F23E6B00BD1E99 /* NSMethodSignature+Cedar.m in Sources */,
 				AEB1A74315F304A9002E4167 /* StubbedMethod.mm in Sources */,
 				AE94D04615F3449500A0C2B7 /* AnyInstanceArgument.mm in Sources */,
 				1FF449B218A0C03900AF94B0 /* CDRBufferedDefaultReporter.m in Sources */,

--- a/Source/Doubles/StubbedMethod.mm
+++ b/Source/Doubles/StubbedMethod.mm
@@ -1,29 +1,50 @@
 #import "StubbedMethod.h"
 #import "AnyArgument.h"
+#import "NSInvocation+Cedar.h"
+#import "NSMethodSignature+Cedar.h"
+#import <objc/runtime.h>
 
 namespace Cedar { namespace Doubles {
 
-    StubbedMethod::StubbedMethod(SEL selector) : InvocationMatcher(selector), exception_to_raise_(0), invocation_block_(0) {}
-    StubbedMethod::StubbedMethod(const char * method_name) : InvocationMatcher(sel_registerName(method_name)), exception_to_raise_(0), invocation_block_(0) {}
+    StubbedMethod::StubbedMethod(SEL selector) : InvocationMatcher(selector), exception_to_raise_(0), invocation_block_(0), implementation_block_(0) {}
+    StubbedMethod::StubbedMethod(const char * method_name) : InvocationMatcher(sel_registerName(method_name)), exception_to_raise_(0), invocation_block_(0), implementation_block_(0) {}
     StubbedMethod::StubbedMethod(const StubbedMethod &rhs)
     : InvocationMatcher(rhs)
     , return_value_argument_(rhs.return_value_argument_)
     , invocation_block_([rhs.invocation_block_ retain])
+    , implementation_block_([rhs.implementation_block_ retain])
     , exception_to_raise_(rhs.exception_to_raise_) {}
 
     /*virtual*/ StubbedMethod::~StubbedMethod() {
         [invocation_block_ release];
+        [implementation_block_ release];
     }
 
     StubbedMethod & StubbedMethod::and_do(invocation_block_t block) {
         if (this->has_return_value()) {
-            NSString * selectorString = NSStringFromSelector(this->selector());
-            [[NSException exceptionWithName:NSInternalInconsistencyException
-                                     reason:[NSString stringWithFormat:@"Multiple return values specified for <%@>", selectorString]
-                                   userInfo:nil] raise];
+            this->raise_for_multiple_return_values();
+        } else if (this->has_implementation_block()) {
+            this->raise_for_multiple_blocks();
         }
 
         invocation_block_ = [block copy];
+        return *this;
+    }
+
+    StubbedMethod & StubbedMethod::and_do_block(implementation_block_t block) {
+        if (![block isKindOfClass:NSClassFromString(@"NSBlock")]) {
+            [[NSException exceptionWithName:NSInternalInconsistencyException
+                                     reason:[NSString stringWithFormat:@"Attempted to stub and do a block that isn't a block for <%@>", NSStringFromSelector(this->selector())]
+                                   userInfo:nil] raise];
+        }
+
+        if (this->has_return_value()) {
+            this->raise_for_multiple_return_values();
+        } else if (this->has_invocation_block()) {
+            this->raise_for_multiple_blocks();
+        }
+
+        implementation_block_ = [block copy];
         return *this;
     }
 
@@ -76,19 +97,65 @@ namespace Cedar { namespace Doubles {
         return false;
     }
 
-    void StubbedMethod::validate_against_instance(id instance) const {
-        this->verify_count_and_types_of_arguments(instance);
-
+    void StubbedMethod::verify_return_value_type(id instance) const {
         if (this->has_return_value()) {
             const char * const methodReturnType = [[instance methodSignatureForSelector:this->selector()] methodReturnType];
             if (!this->return_value().matches_encoding(methodReturnType)) {
-                NSString * selectorString = NSStringFromSelector(this->selector());
                 [[NSException exceptionWithName:NSInternalInconsistencyException
-                                         reason:[NSString stringWithFormat:@"Invalid return value type (%s) for %@", this->return_value().value_encoding(), selectorString]
+                                         reason:[NSString stringWithFormat:@"Invalid return value type '%s' instead of '%s' for <%@>", this->return_value().value_encoding(), methodReturnType, NSStringFromSelector(this->selector())]
                                        userInfo:nil] raise];
-
             }
         }
+    }
+
+    void StubbedMethod::verify_implementation_block_return_type(id instance) const {
+        if (!this->has_implementation_block()) { return; }
+
+        NSMethodSignature *instanceMethodSignature = [instance methodSignatureForSelector:this->selector()];
+        NSMethodSignature *implementationBlockMethodSignature = [NSMethodSignature signatureFromBlock:implementation_block_];
+
+        const char * const methodReturnType = [instanceMethodSignature methodReturnType];
+        const char * const implementationBlockReturnType = [implementationBlockMethodSignature methodReturnType];
+        if (0 != strcmp(implementationBlockReturnType, methodReturnType)) {
+            [[NSException exceptionWithName:NSInternalInconsistencyException
+                                     reason:[NSString stringWithFormat:@"Invalid return type '%s' instead of '%s' for <%@>", implementationBlockReturnType, methodReturnType, NSStringFromSelector(this->selector())]
+                                   userInfo:nil] raise];
+        }
+    }
+
+    void StubbedMethod::verify_implementation_block_arguments(id instance) const {
+        if (!this->has_implementation_block()) { return; }
+
+        NSMethodSignature *instanceMethodSignature = [instance methodSignatureForSelector:this->selector()];
+        NSMethodSignature *implementationBlockMethodSignature = [NSMethodSignature signatureFromBlock:implementation_block_];
+
+        NSUInteger instanceMethodActualArgumentCount = [instanceMethodSignature numberOfArguments]-2;
+        NSUInteger implementationBlockActualArgumentCount = [implementationBlockMethodSignature numberOfArguments]-1;
+
+        if (instanceMethodActualArgumentCount != implementationBlockActualArgumentCount) {
+            NSString * selectorString = NSStringFromSelector(this->selector());
+            [[NSException exceptionWithName:NSInternalInconsistencyException
+                                     reason:[NSString stringWithFormat:@"Wrong number of parameters for <%@>; expected: %lu; actual: %lu (not counting the special first parameter, `id self`)", selectorString, (unsigned long)instanceMethodActualArgumentCount, (unsigned long)implementationBlockActualArgumentCount]
+                                   userInfo:nil] raise];
+        }
+
+        for (NSInteger argIndex=2, blockArgIndex=1; argIndex<[instanceMethodSignature numberOfArguments]; argIndex++, blockArgIndex++) {
+            const char * const instanceMethodArgumentType = [instanceMethodSignature getArgumentTypeAtIndex:argIndex];
+            const char * const implementationBlockArgumentType = [implementationBlockMethodSignature getArgumentTypeAtIndex:blockArgIndex];
+            if (0 != strcmp(instanceMethodArgumentType, implementationBlockArgumentType)) {
+                NSString * selectorString = NSStringFromSelector(this->selector());
+                [[NSException exceptionWithName:NSInternalInconsistencyException
+                                         reason:[NSString stringWithFormat:@"Found argument type '%s', expected '%s'; argument #%lu for <%@>", implementationBlockArgumentType, instanceMethodArgumentType, (unsigned long)argIndex-1, selectorString]
+                                       userInfo:nil] raise];
+            }
+        }
+    }
+
+    void StubbedMethod::validate_against_instance(id instance) const {
+        this->verify_count_and_types_of_arguments(instance);
+        this->verify_return_value_type(instance);
+        this->verify_implementation_block_return_type(instance);
+        this->verify_implementation_block_arguments(instance);
     }
 
     NSString * StubbedMethod::arguments_string() const {
@@ -99,6 +166,20 @@ namespace Cedar { namespace Doubles {
             [argumentsString appendFormat:@"<%@>", (*argument_it)->value_string()];
         }
         return [argumentsString stringByAppendingString:@")"];
+    }
+
+    void StubbedMethod::raise_for_multiple_return_values() const {
+        NSString * selectorString = NSStringFromSelector(this->selector());
+        [[NSException exceptionWithName:NSInternalInconsistencyException
+                                 reason:[NSString stringWithFormat:@"Multiple return values specified for <%@>", selectorString]
+                               userInfo:nil] raise];
+    }
+
+    void StubbedMethod::raise_for_multiple_blocks() const {
+        NSString * selectorString = NSStringFromSelector(this->selector());
+        [[NSException exceptionWithName:NSInternalInconsistencyException
+                                 reason:[NSString stringWithFormat:@"Multiple blocks specified for <%@>", selectorString]
+                               userInfo:nil] raise];
     }
 
     const SEL StubbedMethod::selector() const {
@@ -112,6 +193,8 @@ namespace Cedar { namespace Doubles {
     bool StubbedMethod::invoke(NSInvocation * invocation) const {
         if (exception_to_raise_) {
             @throw exception_to_raise_;
+        } else if (this->has_implementation_block()) {
+            [invocation invokeUsingBlockWithoutSelfArgument:implementation_block_];
         } else if (this->has_invocation_block()) {
             invocation_block_(invocation);
         } else if (this->has_return_value()) {

--- a/Source/Extensions/NSInvocation+Cedar.m
+++ b/Source/Extensions/NSInvocation+Cedar.m
@@ -1,7 +1,13 @@
 #import "NSInvocation+Cedar.h"
+#import "NSMethodSignature+Cedar.h"
+#import "CDRBlockHelper.h"
 #import <objc/runtime.h>
 
 static char COPIED_BLOCKS_KEY;
+
+@interface NSInvocation (UndocumentedPrivate)
+- (void)invokeUsingIMP:(IMP)imp;
+@end
 
 @implementation NSInvocation (Cedar)
 
@@ -26,6 +32,43 @@ static char COPIED_BLOCKS_KEY;
     }
 
     objc_setAssociatedObject(self, &COPIED_BLOCKS_KEY, copiedBlocks, OBJC_ASSOCIATION_RETAIN);
+}
+
+- (NSInvocation *)invocationWithoutCmdArgument {
+    NSMethodSignature *methodSignature = [self methodSignature];
+    NSMethodSignature *adjustedMethodSignature = [methodSignature signatureWithoutSelectorArgument];
+    NSInvocation *adjustedInvocation = [NSInvocation invocationWithMethodSignature:adjustedMethodSignature];
+
+    NSInteger adjustedArgIndex = 0;
+    for (NSInteger argIndex=0; argIndex<[methodSignature numberOfArguments]; argIndex++) {
+        if (argIndex==1) { continue; }
+
+        NSUInteger size;
+        NSGetSizeAndAlignment([methodSignature getArgumentTypeAtIndex:argIndex], &size, NULL);
+        char argBuffer[size];
+
+        [self getArgument:argBuffer atIndex:argIndex];
+        [adjustedInvocation setArgument:argBuffer atIndex:adjustedArgIndex];
+
+        adjustedArgIndex++;
+    }
+
+    return adjustedInvocation;
+}
+
+- (void)invokeUsingBlockWithoutSelfArgument:(id)block {
+    NSInvocation *adjustedInvocation = [self invocationWithoutCmdArgument];
+
+    [adjustedInvocation setTarget:block];
+    struct Block_literal *blockLiteral = (struct Block_literal *)block;
+    [adjustedInvocation invokeUsingIMP:(IMP)blockLiteral->invoke];
+
+    NSUInteger returnValueSize = [[self methodSignature] methodReturnLength];
+    if (returnValueSize > 0) {
+        char returnValueBuffer[returnValueSize];
+        [adjustedInvocation getReturnValue:&returnValueBuffer];
+        [self setReturnValue:&returnValueBuffer];
+    }
 }
 
 @end

--- a/Source/Extensions/NSMethodSignature+Cedar.m
+++ b/Source/Extensions/NSMethodSignature+Cedar.m
@@ -1,0 +1,43 @@
+#import "NSMethodSignature+Cedar.h"
+#import "CDRBlockHelper.h"
+
+static const char *Block_signature(id blockObj) {
+    struct Block_literal *block = (struct Block_literal *)blockObj;
+    union Block_descriptor_rest descriptor_rest = block->descriptor->rest;
+
+    BOOL hasCopyDispose = !!(block->flags & (1<<25));
+
+    const char *signature = hasCopyDispose ? descriptor_rest.layout_with_copy_dispose.signature : descriptor_rest.layout_without_copy_dispose.signature;
+
+    return signature;
+}
+
+@implementation NSMethodSignature (Cedar)
+
++ (NSMethodSignature *)signatureFromBlock:(id)block {
+    const char *signatureTypes = Block_signature(block);
+    NSString *signatureTypesString = [NSString stringWithUTF8String:signatureTypes];
+
+    NSRegularExpression *quotedSubstringsRegex = [NSRegularExpression
+                                                  regularExpressionWithPattern:@"(\".*?\")"
+                                                  options:NSRegularExpressionCaseInsensitive
+                                                  error:NULL];
+
+    NSString *strippedSignatureTypesString = [quotedSubstringsRegex stringByReplacingMatchesInString:signatureTypesString options:0 range:NSMakeRange(0, [signatureTypesString length]) withTemplate:@""];
+
+    return [NSMethodSignature signatureWithObjCTypes:[strippedSignatureTypesString UTF8String]];
+}
+
+- (NSMethodSignature *)signatureWithoutSelectorArgument {
+    NSAssert([self numberOfArguments]>1 && strcmp([self getArgumentTypeAtIndex:1], ":")==0, @"Unable to remove _cmd from a method signature without a _cmd argument");
+
+    NSMutableString *modifiedTypesString = [[NSMutableString alloc] initWithUTF8String:[self methodReturnType]];
+    for (NSInteger argIndex=0; argIndex<[self numberOfArguments]; argIndex++) {
+        if (argIndex==1) { continue; }
+        [modifiedTypesString appendFormat:@"%s", [self getArgumentTypeAtIndex:argIndex]];
+    }
+
+    return [NSMethodSignature signatureWithObjCTypes:[modifiedTypesString UTF8String]];
+}
+
+@end

--- a/Source/Headers/CDRBlockHelper.h
+++ b/Source/Headers/CDRBlockHelper.h
@@ -1,0 +1,25 @@
+
+// See http://clang.llvm.org/docs/Block-ABI-Apple.html
+struct Block_literal {
+    void *isa;
+    int flags;
+    int reserved;
+    void (*invoke)(void *, ...);
+    struct Block_descriptor {
+        unsigned long int reserved;
+        unsigned long int size;
+
+        union Block_descriptor_rest {
+            struct rest_with_copy_dispose {
+                void (*copy_helper)(void *dst, void *src);     // IFF (1<<25)
+                void (*dispose_helper)(void *src);             // IFF (1<<25)
+                const char *signature;
+            } layout_with_copy_dispose;
+
+            struct rest_without_copy_dispose {
+                const char *signature;
+            } layout_without_copy_dispose;
+        } rest;
+    } *descriptor;
+};
+

--- a/Source/Headers/Doubles/StubbedMethod.h
+++ b/Source/Headers/Doubles/StubbedMethod.h
@@ -10,6 +10,7 @@ namespace Cedar { namespace Doubles {
     class StubbedMethod : private InvocationMatcher {
     private:
         typedef void (^invocation_block_t)(NSInvocation *);
+        typedef id implementation_block_t;
 
     private:
         StubbedMethod & operator=(const StubbedMethod &);
@@ -22,6 +23,7 @@ namespace Cedar { namespace Doubles {
 
         template<typename T>
         StubbedMethod & and_return(const T &);
+        StubbedMethod & and_do_block(implementation_block_t block);
         StubbedMethod & and_do(invocation_block_t);
 
         StubbedMethod & with(const Argument::shared_ptr_t argument);
@@ -61,20 +63,27 @@ namespace Cedar { namespace Doubles {
     private:
         bool has_return_value() const { return return_value_argument_.get(); };
         bool has_invocation_block() const { return invocation_block_; }
+        bool has_implementation_block() const { return implementation_block_; }
 
+        void verify_return_value_type(id instance) const;
+        void verify_implementation_block_return_type(id instance) const;
+        void verify_implementation_block_arguments(id instance) const;
+
+        void raise_for_multiple_return_values() const;
+        void raise_for_multiple_blocks() const;
     private:
         Argument::shared_ptr_t return_value_argument_;
         invocation_block_t invocation_block_;
+        implementation_block_t implementation_block_;
         NSObject * exception_to_raise_;
     };
 
     template<typename T>
     StubbedMethod & StubbedMethod::and_return(const T & return_value) {
         if (this->has_invocation_block()) {
-            NSString * selectorString = NSStringFromSelector(this->selector());
-            [[NSException exceptionWithName:NSInternalInconsistencyException
-                                     reason:[NSString stringWithFormat:@"Multiple return values specified for <%@>", selectorString]
-                                   userInfo:nil] raise];
+            this->raise_for_multiple_return_values();
+        } else if (this->has_implementation_block()) {
+            this->raise_for_multiple_return_values();
         }
 
         return_value_argument_ = Argument::shared_ptr_t(new ReturnValue<T>(return_value));

--- a/Source/Headers/Extensions/NSInvocation+Cedar.h
+++ b/Source/Headers/Extensions/NSInvocation+Cedar.h
@@ -3,5 +3,7 @@
 @interface NSInvocation (Cedar)
 
 - (void)copyBlockArguments;
+- (NSInvocation *)invocationWithoutCmdArgument;
+- (void)invokeUsingBlockWithoutSelfArgument:(id)block;
 
 @end

--- a/Source/Headers/Extensions/NSMethodSignature+Cedar.h
+++ b/Source/Headers/Extensions/NSMethodSignature+Cedar.h
@@ -1,0 +1,8 @@
+#import <Foundation/Foundation.h>
+
+@interface NSMethodSignature (Cedar)
+
++ (NSMethodSignature *)signatureFromBlock:(id)block;
+- (NSMethodSignature *)signatureWithoutSelectorArgument;
+
+@end

--- a/Spec/Support/SimpleIncrementer.h
+++ b/Spec/Support/SimpleIncrementer.h
@@ -1,5 +1,9 @@
 #import <Foundation/Foundation.h>
 
+typedef struct {
+    size_t a, b, c, d;
+} LargeIncrementerStruct;
+
 @protocol InheritedProtocol<NSObject>
 @end
 
@@ -17,7 +21,8 @@
 - (void)methodWithBlock:(void(^)())blockArgument;
 - (void)methodWithCString:(char *)string;
 - (NSNumber *)methodWithNumber1:(NSNumber *)arg1 andNumber2:(NSNumber *)arg2;
-
+- (double)methodWithDouble1:(double)double1 andDouble2:(double)double2;
+- (LargeIncrementerStruct)methodWithLargeStruct1:(LargeIncrementerStruct)struct1 andLargeStruct2:(LargeIncrementerStruct)struct2;
 @optional
 - (size_t)whatIfIIncrementedBy:(size_t)amount;
 

--- a/Spec/Support/SimpleIncrementer.m
+++ b/Spec/Support/SimpleIncrementer.m
@@ -50,4 +50,12 @@
     return @([arg1 floatValue] * [arg2 floatValue]);
 }
 
+- (double)methodWithDouble1:(double)double1 andDouble2:(double)double2 {
+    return double1*double2;
+}
+
+- (LargeIncrementerStruct)methodWithLargeStruct1:(LargeIncrementerStruct)struct1 andLargeStruct2:(LargeIncrementerStruct)struct2 {
+    return (LargeIncrementerStruct){};
+}
+
 @end


### PR DESCRIPTION
This iteration on the feature forgoes using imp_implementationWithBlock altogether, and instead has NSInvocation call directly into the stub block's code. This is done after modifying the invocation to put the pointer to the block in arg 0, and remove the SEL _cmd argument altogether. This achieves the goal of not requiring the user of the API to include an initial 'id obj' parameter in the block, while simultaneously having no restrictions on the quantity or types of the arguments of the method being stubbed. Additionally, no third-party dependencies are required to make it happen.

This code includes full type checking on the return value and arguments of the provided block.
