### PR TITLE
Fix typing checking for and_do_block when the stubbed method has a block argument

### DIFF
--- a/Source/Extensions/NSMethodSignature+Cedar.m
+++ b/Source/Extensions/NSMethodSignature+Cedar.m
@@ -19,7 +19,7 @@ static const char *Block_signature(id blockObj) {
     NSString *signatureTypesString = [NSString stringWithUTF8String:signatureTypes];
 
     NSRegularExpression *quotedSubstringsRegex = [NSRegularExpression
-                                                  regularExpressionWithPattern:@"(\".*?\")"
+                                                  regularExpressionWithPattern:@"(\".*?\")|(<.*?>)"
                                                   options:NSRegularExpressionCaseInsensitive
                                                   error:NULL];
 

--- a/Spec/Doubles/CedarDoubleSharedExamples.mm
+++ b/Spec/Doubles/CedarDoubleSharedExamples.mm
@@ -352,6 +352,24 @@ sharedExamplesFor(@"a Cedar double", ^(NSDictionary *sharedContext) {
                 });
             });
 
+            context(@"with a valid block that takes a complex block as a parameter", ^{
+                ComplexIncrementerBlock sent_argument = ^LargeIncrementerStruct(NSNumber *, LargeIncrementerStruct, NSError *){ return (LargeIncrementerStruct){}; };
+                __block ComplexIncrementerBlock received_argument;
+
+                beforeEach(^{
+                    received_argument = nil;
+
+                    myDouble stub_method("methodWithNumber:complexBlock:").and_do_block(^(NSNumber *, ComplexIncrementerBlock block) {
+                        received_argument = block;
+                    });
+                    [myDouble methodWithNumber:@(1) complexBlock:sent_argument];
+                });
+
+                it(@"should be passed the correct block argument", ^{
+                    received_argument should equal(sent_argument);
+                });
+            });
+
             context(@"with something not a block", ^{
                 it(@"should raise an exception", ^{
                     ^{ myDouble stub_method("value").and_do_block(@(2)); } should raise_exception.with_reason([NSString stringWithFormat:@"Attempted to stub and do a block that isn't a block for <value>"]);

--- a/Spec/Support/SimpleIncrementer.h
+++ b/Spec/Support/SimpleIncrementer.h
@@ -4,6 +4,8 @@ typedef struct {
     size_t a, b, c, d;
 } LargeIncrementerStruct;
 
+typedef LargeIncrementerStruct (^ComplexIncrementerBlock)(NSNumber *, LargeIncrementerStruct, NSError *);
+
 @protocol InheritedProtocol<NSObject>
 @end
 
@@ -23,9 +25,9 @@ typedef struct {
 - (NSNumber *)methodWithNumber1:(NSNumber *)arg1 andNumber2:(NSNumber *)arg2;
 - (double)methodWithDouble1:(double)double1 andDouble2:(double)double2;
 - (LargeIncrementerStruct)methodWithLargeStruct1:(LargeIncrementerStruct)struct1 andLargeStruct2:(LargeIncrementerStruct)struct2;
+- (void)methodWithNumber:(NSNumber *)number complexBlock:(ComplexIncrementerBlock)block;
 @optional
 - (size_t)whatIfIIncrementedBy:(size_t)amount;
-
 @end
 
 @interface IncrementerBase : NSObject

--- a/Spec/Support/SimpleIncrementer.m
+++ b/Spec/Support/SimpleIncrementer.m
@@ -58,4 +58,7 @@
     return (LargeIncrementerStruct){};
 }
 
+- (void)methodWithNumber:(NSNumber *)number complexBlock:(ComplexIncrementerBlock)block {
+}
+
 @end


### PR DESCRIPTION
Blocks' signatures have extra type information which isn't present in methods' signatures. In particular, the signature of a block which receives another block includes the complete return type and parameter information of the block argument.  This results in type mismatches when the type strings are compared. We have to strip out some of this information so that we match only against the information which is also included in the stubbed method's signature.

Thanks to @idoru for discovering the issue.
