### PR TITLE
Stop Travis building against iOS SDK 5.0&5.1

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,6 @@
 language: objective-c
 
 rvm:
-  - "system; export CEDAR_SDK_VERSION=5.0 #"
-  - "system; export CEDAR_SDK_VERSION=5.1 #"
   - "system; export CEDAR_SDK_VERSION=6.0 #"
   - "system; export CEDAR_SDK_VERSION=6.1 #"
   - "system; export CEDAR_SDK_VERSION=7.0 #"


### PR DESCRIPTION
As discussed, we want to drop support for building with the iOS 5.x SDKs. In essence, this means we support Xcode 4.5 (September 2012) and newer.

This drops the Travis build matrix to 15 builds, until we are able to start building with 7.1.

[#69581074]
