### PR TITLE
Fix iOS specs when run on the 64-bit simulator.

### DIFF
--- a/Source/Headers/CDRExampleBase.h
+++ b/Source/Headers/CDRExampleBase.h
@@ -2,8 +2,7 @@
 #import "CDRExampleParent.h"
 
 @class CDRSpec, CDRReportDispatcher;
-
-enum CDRExampleState {
+typedef NS_ENUM(NSInteger, CDRExampleState) {
     CDRExampleStateIncomplete = 0x00,
     CDRExampleStateSkipped = 0x01,
     CDRExampleStatePassed = 0x03,
@@ -11,7 +10,6 @@ enum CDRExampleState {
     CDRExampleStateFailed = 0x0F,
     CDRExampleStateError = 0x1F
 };
-typedef enum CDRExampleState CDRExampleState;
 
 @interface CDRExampleBase : NSObject {
   NSString *text_;


### PR DESCRIPTION
I noticed that the iOSSpecs target wouldn't build on 64-bit simulator destinations due to failures in the CDRExampleStateMap spec, because the default enum storage type isn't pointer-sized there. Explicitly setting the storage type fixes this. Also, this takes advantage of a feature that wasn't available until a few minutes ago when we supported building with the 5.0 SDK :smile: 
