### PR TITLE
Cedar should produce intelligible error messages for type mismatches

### DIFF
--- a/Cedar.xcodeproj/project.pbxproj
+++ b/Cedar.xcodeproj/project.pbxproj
@@ -75,6 +75,10 @@
 		22B6A22715B7ACF800960ADE /* InvocationMatcher.h in Copy headers to framework */ = {isa = PBXBuildFile; fileRef = AE597B4015B0638B00EEF305 /* InvocationMatcher.h */; };
 		22FB7B4416ACBB3A00012D69 /* HeadlessSimulatorWorkaround.m in Sources */ = {isa = PBXBuildFile; fileRef = 22FB7B4316ACBB3A00012D69 /* HeadlessSimulatorWorkaround.m */; };
 		342F5D0B18F430DB00F38E35 /* QuartzCore.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 342F5D0A18F430DB00F38E35 /* QuartzCore.framework */; };
+		34681C2C18FE451E009D38AC /* CDRTypeUtilities.m in Sources */ = {isa = PBXBuildFile; fileRef = 34681C2B18FE451E009D38AC /* CDRTypeUtilities.m */; };
+		34681C2E18FE4884009D38AC /* CDRTypeUtilities.m in Sources */ = {isa = PBXBuildFile; fileRef = 34681C2B18FE451E009D38AC /* CDRTypeUtilities.m */; };
+		34681C3018FE4B68009D38AC /* CDRTypeUtilitiesSpec.mm in Sources */ = {isa = PBXBuildFile; fileRef = 34681C2F18FE4B68009D38AC /* CDRTypeUtilitiesSpec.mm */; };
+		34681C3118FE4B68009D38AC /* CDRTypeUtilitiesSpec.mm in Sources */ = {isa = PBXBuildFile; fileRef = 34681C2F18FE4B68009D38AC /* CDRTypeUtilitiesSpec.mm */; };
 		34ADE41818F23C8E00BD1E99 /* NSMethodSignature+Cedar.m in Sources */ = {isa = PBXBuildFile; fileRef = 34ADE41618F23C8E00BD1E99 /* NSMethodSignature+Cedar.m */; };
 		34ADE41918F23E6B00BD1E99 /* NSMethodSignature+Cedar.m in Sources */ = {isa = PBXBuildFile; fileRef = 34ADE41618F23C8E00BD1E99 /* NSMethodSignature+Cedar.m */; };
 		34D4B5C318F3AE0400FB2C3B /* UIKitContainSpec.mm in Sources */ = {isa = PBXBuildFile; fileRef = 34D4B5C118F3ADFF00FB2C3B /* UIKitContainSpec.mm */; };
@@ -624,6 +628,9 @@
 		342F5D0A18F430DB00F38E35 /* QuartzCore.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = QuartzCore.framework; path = Platforms/iPhoneOS.platform/Developer/SDKs/iPhoneOS7.1.sdk/System/Library/Frameworks/QuartzCore.framework; sourceTree = DEVELOPER_DIR; };
 		3460488818F26F5400BC93B6 /* NSMethodSignature+Cedar.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = "NSMethodSignature+Cedar.h"; sourceTree = "<group>"; };
 		3460489318F2DBBF00BC93B6 /* CDRBlockHelper.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = CDRBlockHelper.h; sourceTree = "<group>"; };
+		34681C2B18FE451E009D38AC /* CDRTypeUtilities.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = CDRTypeUtilities.m; sourceTree = "<group>"; };
+		34681C2D18FE4611009D38AC /* CDRTypeUtilities.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = CDRTypeUtilities.h; sourceTree = "<group>"; };
+		34681C2F18FE4B68009D38AC /* CDRTypeUtilitiesSpec.mm */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.objcpp; path = CDRTypeUtilitiesSpec.mm; sourceTree = "<group>"; };
 		34ADE41618F23C8E00BD1E99 /* NSMethodSignature+Cedar.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = "NSMethodSignature+Cedar.m"; sourceTree = "<group>"; };
 		34D4B5C118F3ADFF00FB2C3B /* UIKitContainSpec.mm */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.objcpp; path = UIKitContainSpec.mm; sourceTree = "<group>"; };
 		34D4B5C418F3B68900FB2C3B /* UIKitComparatorsContainer.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = UIKitComparatorsContainer.h; sourceTree = "<group>"; };
@@ -1376,6 +1383,7 @@
 				AE8C881113626FE6006C9305 /* CDRSpecFailure.m */,
 				AEEE1FC811DC27B800029872 /* CDRFunctions.m */,
 				969B6F82160C61E000C7C792 /* CDRSymbolicator.m */,
+				34681C2B18FE451E009D38AC /* CDRTypeUtilities.m */,
 			);
 			path = Source;
 			sourceTree = "<group>";
@@ -1403,6 +1411,7 @@
 				AEEE1FD311DC27B800029872 /* Cedar.h */,
 				AEEE1FDB11DC27B800029872 /* SpecHelper.h */,
 				3460489318F2DBBF00BC93B6 /* CDRBlockHelper.h */,
+				34681C2D18FE4611009D38AC /* CDRTypeUtilities.h */,
 			);
 			path = Headers;
 			sourceTree = "<group>";
@@ -1459,6 +1468,7 @@
 				AEEE1FF111DC27B800029872 /* SpecSpec.mm */,
 				AEEE1FF211DC27B800029872 /* SpecSpec2.m */,
 				AEEE1FEF11DC27B800029872 /* main.m */,
+				34681C2F18FE4B68009D38AC /* CDRTypeUtilitiesSpec.mm */,
 			);
 			path = Spec;
 			sourceTree = "<group>";
@@ -2159,6 +2169,7 @@
 				AE8C881413626FE7006C9305 /* CDRSpecFailure.m in Sources */,
 				4206446A139B44F600C85605 /* CDRTeamCityReporter.m in Sources */,
 				96EA1CA8142C6425001A78E0 /* CDROTestReporter.m in Sources */,
+				34681C2C18FE451E009D38AC /* CDRTypeUtilities.m in Sources */,
 				96EA1CAA142C6425001A78E0 /* CDROTestRunner.m in Sources */,
 				9637852B1491D6D40059C9F6 /* CDROTestHelper.m in Sources */,
 				492951E01481AAFA00FA8916 /* CDRJUnitXMLReporter.m in Sources */,
@@ -2201,6 +2212,7 @@
 				AE8C87AE136245BB006C9305 /* ExpectFailureWithMessage.m in Sources */,
 				96EA1CBA142C6560001A78E0 /* CDRSpecFailureSpec.mm in Sources */,
 				AEF7301B13ECC4AE00786282 /* BeCloseToSpec.mm in Sources */,
+				34681C3018FE4B68009D38AC /* CDRTypeUtilitiesSpec.mm in Sources */,
 				AE53B68417E7CD8D00D83D5E /* ObjectWithWeakDelegate.m in Sources */,
 				AE80788D183C71950078C608 /* ArgumentReleaser.m in Sources */,
 				AE4A945B187F7E52008566F5 /* BeFalsySpec.mm in Sources */,
@@ -2274,6 +2286,7 @@
 				1F483E34187D3CD200521F81 /* CDROTestNamer.m in Sources */,
 				4206446B139B44F600C85605 /* CDRTeamCityReporter.m in Sources */,
 				96EA1CA9142C6425001A78E0 /* CDROTestReporter.m in Sources */,
+				34681C2E18FE4884009D38AC /* CDRTypeUtilities.m in Sources */,
 				1FE15C201869091900207F0C /* CDRReportDispatcher.m in Sources */,
 				960118BC1434867E00825FFF /* CDROTestIPhoneRunner.m in Sources */,
 				9637852C1491D6D40059C9F6 /* CDROTestHelper.m in Sources */,
@@ -2341,6 +2354,7 @@
 				AE18A80B13F4640600C8872C /* ContainSpec.mm in Sources */,
 				AED10EBD18F46C0E00950904 /* FooSuperclass.m in Sources */,
 				AE6F3F351458D7C100C98F1E /* BeGreaterThanSpec.mm in Sources */,
+				34681C3118FE4B68009D38AC /* CDRTypeUtilitiesSpec.mm in Sources */,
 				AE53B68217E7BCE700D83D5E /* CedarNiceFakeSharedExamples.mm in Sources */,
 				AEF3300A145B4E3B002F93BB /* BeGTESpec.mm in Sources */,
 				AEF33015145B6188002F93BB /* BeLessThanSpec.mm in Sources */,

--- a/Source/CDRTypeUtilities.m
+++ b/Source/CDRTypeUtilities.m
@@ -1,0 +1,129 @@
+#import "CDRTypeUtilities.h"
+
+@implementation CDRTypeUtilities
+
+static NSDictionary *typeEncodingMapping;
+static NSDictionary *typeEncodingModifiersMapping;
+static NSCharacterSet *typeEncodingStringsCharacterSet;
+static NSCharacterSet *typeEncodingModifiersCharacterSet;
+
++ (void)initialize {
+    // See: https://developer.apple.com/library/mac/documentation/Cocoa/Conceptual/ObjCRuntimeGuide/Articles/ocrtTypeEncodings.html
+    typeEncodingMapping = [@{ @"c": @"char",
+                              @"i": @"int",
+                              @"s": @"short",
+                              @"l": @"long",
+                              @"q": @"long long",
+                              @"C": @"unsigned char",
+                              @"I": @"unsigned int",
+                              @"S": @"unsigned short",
+                              @"L": @"unsigned long",
+                              @"Q": @"unsigned long long",
+                              @"f": @"float",
+                              @"d": @"double",
+                              @"B": @"bool",
+                              @"v": @"void",
+                              @"*": @"char *",
+                              @"@": @"id",
+                              @"#": @"Class",
+                              @":": @"SEL",
+                              @"@?": @"<a block>",
+                              @"?": @"<unknown type>" } retain];
+    typeEncodingModifiersMapping = [@{ @"r": @"const",
+                                       @"n": @"in",
+                                       @"N": @"inout",
+                                       @"o": @"out",
+                                       @"O": @"bycopy",
+                                       @"R": @"byref",
+                                       @"V": @"oneway" } retain];
+    typeEncodingStringsCharacterSet = [[NSCharacterSet characterSetWithCharactersInString:[[typeEncodingMapping allKeys] componentsJoinedByString:@""]] retain];
+    typeEncodingModifiersCharacterSet = [[NSCharacterSet characterSetWithCharactersInString:[[typeEncodingModifiersMapping allKeys] componentsJoinedByString:@""]] retain];
+}
+
++ (NSString *)typeNameForEncoding:(const char *)encodingStr {
+    if (!encodingStr || encodingStr[0] == '\0') { return nil; }
+
+    NSScanner *scanner = [NSScanner scannerWithString:[NSString stringWithUTF8String:encodingStr]];
+    NSInteger arraySize = 0;
+    NSInteger pointerCount = 0;
+    NSString *typeName = nil;
+    NSString *modifiers = nil;
+
+    if ([scanner scanCharactersFromSet:[NSCharacterSet characterSetWithCharactersInString:@"["] intoString:NULL]) {
+        [scanner scanInteger:&arraySize];
+    }
+
+    modifiers = [self scanTypeEncodingModifiersFromScanner:scanner];
+
+    NSString *pointerModifiers;
+    if ([scanner scanCharactersFromSet:[NSCharacterSet characterSetWithCharactersInString:@"^"] intoString:&pointerModifiers]) {
+        pointerCount = [pointerModifiers length];
+    }
+
+    typeName = [self scanComplexTypeNameFromScanner:scanner];
+
+    if (!typeName) {
+        NSString *baseEncoding;
+        if ([scanner scanCharactersFromSet:typeEncodingStringsCharacterSet intoString:&baseEncoding]) {
+            typeName = typeEncodingMapping[baseEncoding];
+        }
+    }
+
+    if (typeName) {
+        NSMutableString *fullTypeName = [typeName mutableCopy];
+
+        if (modifiers) {
+            [fullTypeName insertString:[modifiers stringByAppendingString:@" "] atIndex:0];
+        }
+
+        for (int i=0; i<pointerCount; i++) {
+            if (i==0 && ![fullTypeName hasSuffix:@"*"]) {
+                [fullTypeName appendString:@" "];
+            }
+            [fullTypeName appendString:@"*"];
+        }
+
+        if (arraySize > 0) {
+            [fullTypeName appendFormat:@"[%ld]", (long)arraySize];
+        }
+
+        return fullTypeName;
+    } else {
+        return [NSString stringWithUTF8String:encodingStr];
+    }
+}
+
++ (NSString *)scanTypeEncodingModifiersFromScanner:(NSScanner *)scanner {
+    NSString *modifiers = nil;
+
+    if ([scanner scanCharactersFromSet:typeEncodingModifiersCharacterSet intoString:&modifiers]) {
+        NSMutableArray *modifierNames = [NSMutableArray array];
+        [modifiers enumerateSubstringsInRange:NSMakeRange(0, [modifiers length]) options:NSStringEnumerationByComposedCharacterSequences usingBlock:^(NSString *substring, NSRange substringRange, NSRange enclosingRange, BOOL *stop) {
+            NSString *modifierName = typeEncodingModifiersMapping[substring];
+            if (modifierName) {
+                [modifierNames addObject:modifierName];
+            }
+        }];
+        modifiers = [modifierNames count]>0 ? [modifierNames componentsJoinedByString:@" "] : nil;
+    }
+
+    return modifiers;
+}
+
++ (NSString *)scanComplexTypeNameFromScanner:(NSScanner *)scanner {
+    NSString *complexTypeIntroducer;
+    if ([scanner scanCharactersFromSet:[NSCharacterSet characterSetWithCharactersInString:@"{("] intoString:&complexTypeIntroducer]) {
+        NSString *complexType = [complexTypeIntroducer isEqualToString:@"{"] ? @"struct" : @"union";
+        NSString *complexTypeName;
+        [scanner scanUpToString:@"=" intoString:&complexTypeName];
+
+        if ([complexTypeName isEqualToString:@"?"]) {
+            return [@"untagged " stringByAppendingString:complexType];
+        } else {
+            return [complexType stringByAppendingFormat:@" %@", complexTypeName];
+        }
+    }
+    return nil;
+}
+
+@end

--- a/Source/Doubles/InvocationMatcher.mm
+++ b/Source/Doubles/InvocationMatcher.mm
@@ -1,5 +1,6 @@
 #import "InvocationMatcher.h"
 #import <objc/runtime.h>
+#import "CDRTypeUtilities.h"
 
 namespace Cedar { namespace Doubles {
 
@@ -73,9 +74,10 @@ namespace Cedar { namespace Doubles {
             const char * actual_argument_encoding = [methodSignature getArgumentTypeAtIndex:index];
             if (!(*cit)->matches_encoding(actual_argument_encoding)) {
                 NSString * selectorString = NSStringFromSelector(this->selector());
-                NSString *reason = [NSString stringWithFormat:@"Attempt to compare expected argument <%@> with actual argument type %s; argument #%lu for <%@>",
+                NSString *reason = [NSString stringWithFormat:@"Attempt to compare expected argument <%@> of type '%@' with actual argument type '%@'; argument #%lu for <%@>",
                                     (*cit)->value_string(),
-                                    actual_argument_encoding,
+                                    [CDRTypeUtilities typeNameForEncoding:(*cit)->value_encoding()],
+                                    [CDRTypeUtilities typeNameForEncoding:actual_argument_encoding],
                                     (unsigned long)(index - OBJC_DEFAULT_ARGUMENT_COUNT + 1),
                                     selectorString];
                 [[NSException exceptionWithName:NSInternalInconsistencyException reason:reason userInfo:nil] raise];

--- a/Source/Doubles/StubbedMethod.mm
+++ b/Source/Doubles/StubbedMethod.mm
@@ -1,5 +1,6 @@
 #import "StubbedMethod.h"
 #import "AnyArgument.h"
+#import "CDRTypeUtilities.h"
 #import "NSInvocation+Cedar.h"
 #import "NSMethodSignature+Cedar.h"
 #import <objc/runtime.h>
@@ -115,7 +116,7 @@ namespace Cedar { namespace Doubles {
             const char * const methodReturnType = [[instance methodSignatureForSelector:this->selector()] methodReturnType];
             if (!this->return_value().matches_encoding(methodReturnType)) {
                 [[NSException exceptionWithName:NSInternalInconsistencyException
-                                         reason:[NSString stringWithFormat:@"Invalid return value type '%s' instead of '%s' for <%@>", this->return_value().value_encoding(), methodReturnType, NSStringFromSelector(this->selector())]
+                                         reason:[NSString stringWithFormat:@"Invalid return value type '%@' instead of '%@' for <%@>", [CDRTypeUtilities typeNameForEncoding:this->return_value().value_encoding()], [CDRTypeUtilities typeNameForEncoding:methodReturnType], NSStringFromSelector(this->selector())]
                                        userInfo:nil] raise];
             }
         }
@@ -131,7 +132,7 @@ namespace Cedar { namespace Doubles {
         const char * const implementationBlockReturnType = [implementationBlockMethodSignature methodReturnType];
         if (0 != strcmp(implementationBlockReturnType, methodReturnType)) {
             [[NSException exceptionWithName:NSInternalInconsistencyException
-                                     reason:[NSString stringWithFormat:@"Invalid return type '%s' instead of '%s' for <%@>", implementationBlockReturnType, methodReturnType, NSStringFromSelector(this->selector())]
+                                     reason:[NSString stringWithFormat:@"Invalid return type '%@' instead of '%@' for <%@>", [CDRTypeUtilities typeNameForEncoding:implementationBlockReturnType], [CDRTypeUtilities typeNameForEncoding:methodReturnType], NSStringFromSelector(this->selector())]
                                    userInfo:nil] raise];
         }
     }
@@ -158,7 +159,7 @@ namespace Cedar { namespace Doubles {
             if (0 != strcmp(instanceMethodArgumentType, implementationBlockArgumentType)) {
                 NSString * selectorString = NSStringFromSelector(this->selector());
                 [[NSException exceptionWithName:NSInternalInconsistencyException
-                                         reason:[NSString stringWithFormat:@"Found argument type '%s', expected '%s'; argument #%lu for <%@>", implementationBlockArgumentType, instanceMethodArgumentType, (unsigned long)argIndex-1, selectorString]
+                                         reason:[NSString stringWithFormat:@"Found argument type '%@', expected '%@'; argument #%lu for <%@>", [CDRTypeUtilities typeNameForEncoding:implementationBlockArgumentType], [CDRTypeUtilities typeNameForEncoding:instanceMethodArgumentType], (unsigned long)argIndex-1, selectorString]
                                        userInfo:nil] raise];
             }
         }

--- a/Source/Headers/CDRTypeUtilities.h
+++ b/Source/Headers/CDRTypeUtilities.h
@@ -1,0 +1,5 @@
+#import <Foundation/Foundation.h>
+
+@interface CDRTypeUtilities : NSObject
++ (NSString *)typeNameForEncoding:(const char *)encoding;
+@end

--- a/Spec/CDRTypeUtilitiesSpec.mm
+++ b/Spec/CDRTypeUtilitiesSpec.mm
@@ -1,0 +1,198 @@
+#import <Cedar/SpecHelper.h>
+#import "CDRTypeUtilities.h"
+
+using namespace Cedar::Matchers;
+using namespace Cedar::Doubles;
+
+SPEC_BEGIN(CDRTypeUtilitiesSpec)
+
+describe(@"CDRTypeUtilities", ^{
+    describe(@"mapping type encodings to type names", ^{
+        it(@"should return the type name for 'c'", ^{
+            [CDRTypeUtilities typeNameForEncoding:"c"] should equal(@"char");
+        });
+
+        it(@"should return the type name for 'i'", ^{
+            [CDRTypeUtilities typeNameForEncoding:"i"] should equal(@"int");
+        });
+
+        it(@"should return the type name for 's'", ^{
+            [CDRTypeUtilities typeNameForEncoding:"s"] should equal(@"short");
+        });
+
+        it(@"should return the type name for 'l'", ^{
+            [CDRTypeUtilities typeNameForEncoding:"l"] should equal(@"long");
+        });
+
+        it(@"should return the type name for 'q'", ^{
+            [CDRTypeUtilities typeNameForEncoding:"q"] should equal(@"long long");
+        });
+
+        it(@"should return the type name for 'C'", ^{
+            [CDRTypeUtilities typeNameForEncoding:"C"] should equal(@"unsigned char");
+        });
+
+        it(@"should return the type name for 'I'", ^{
+            [CDRTypeUtilities typeNameForEncoding:"I"] should equal(@"unsigned int");
+        });
+
+        it(@"should return the type name for 'S'", ^{
+            [CDRTypeUtilities typeNameForEncoding:"S"] should equal(@"unsigned short");
+        });
+
+        it(@"should return the type name for 'L'", ^{
+            [CDRTypeUtilities typeNameForEncoding:"L"] should equal(@"unsigned long");
+        });
+
+        it(@"should return the type name for 'Q'", ^{
+            [CDRTypeUtilities typeNameForEncoding:"Q"] should equal(@"unsigned long long");
+        });
+
+        it(@"should return the type name for 'f'", ^{
+            [CDRTypeUtilities typeNameForEncoding:"f"] should equal(@"float");
+        });
+
+        it(@"should return the type name for 'd'", ^{
+            [CDRTypeUtilities typeNameForEncoding:"d"] should equal(@"double");
+        });
+
+        it(@"should return the type name for 'B'", ^{
+            [CDRTypeUtilities typeNameForEncoding:"B"] should equal(@"bool");
+        });
+
+        it(@"should return the type name for 'v'", ^{
+            [CDRTypeUtilities typeNameForEncoding:"v"] should equal(@"void");
+        });
+
+        it(@"should return the type name for '*'", ^{
+            [CDRTypeUtilities typeNameForEncoding:"*"] should equal(@"char *");
+        });
+
+        it(@"should return the type name for '@'", ^{
+            [CDRTypeUtilities typeNameForEncoding:"@"] should equal(@"id");
+        });
+
+        it(@"should return the type name for '#'", ^{
+            [CDRTypeUtilities typeNameForEncoding:"#"] should equal(@"Class");
+        });
+
+        it(@"should return the type name for ':'", ^{
+            [CDRTypeUtilities typeNameForEncoding:":"] should equal(@"SEL");
+        });
+
+        it(@"should return the type name for '@?'", ^{
+            [CDRTypeUtilities typeNameForEncoding:"@?"] should equal(@"<a block>");
+        });
+
+        it(@"should return the type name for '?'", ^{
+            [CDRTypeUtilities typeNameForEncoding:"?"] should equal(@"<unknown type>");
+        });
+
+        context(@"for structs", ^{
+            /*
+            struct a_tagged_struct { int a; };
+            typedef struct { int a; } an_untagged_struct;
+             */
+
+            it(@"should return the type name for '{a_tagged_struct=i}'", ^{
+                [CDRTypeUtilities typeNameForEncoding:"{a_tagged_struct=i}"] should equal(@"struct a_tagged_struct");
+            });
+
+            it(@"should return the type name for '{?=i}'", ^{
+                [CDRTypeUtilities typeNameForEncoding:"{?=i}"] should equal(@"untagged struct");
+            });
+        });
+
+        context(@"for unions", ^{
+            /*
+            union a_tagged_union { int a; };
+            typedef union { int a; } an_untagged_union;
+             */
+
+            it(@"should return the type name for '(a_tagged_union=i)'", ^{
+
+                [CDRTypeUtilities typeNameForEncoding:"(a_tagged_union=i)"] should equal(@"union a_tagged_union");
+            });
+
+            it(@"should return the type name for '(?=i)'", ^{
+                [CDRTypeUtilities typeNameForEncoding:"(?=i)"] should equal(@"untagged union");
+            });
+        });
+
+        context(@"for arrays", ^{
+            it(@"should return the type name for '[2i]'", ^{
+                [CDRTypeUtilities typeNameForEncoding:"[2i]"] should equal(@"int[2]");
+            });
+
+            it(@"should return the type name for '[2@?]'", ^{
+                [CDRTypeUtilities typeNameForEncoding:"[2@?]"] should equal(@"<a block>[2]");
+            });
+
+            it(@"should return the type name for '[2{a_tagged_struct=i}]'", ^{
+                [CDRTypeUtilities typeNameForEncoding:"[2{a_tagged_struct=i}]"] should equal(@"struct a_tagged_struct[2]");
+            });
+        });
+
+        context(@"for pointers", ^{
+            it(@"should return the type name for '^i'", ^{
+                [CDRTypeUtilities typeNameForEncoding:"^i"] should equal(@"int *");
+            });
+
+            it(@"should return the type name for '^@'", ^{
+                [CDRTypeUtilities typeNameForEncoding:"^@"] should equal(@"id *");
+            });
+
+            it(@"should return the type name for '^^i'", ^{
+                [CDRTypeUtilities typeNameForEncoding:"^^i"] should equal(@"int **");
+            });
+
+            it(@"should return the type name for '^{a_tagged_struct=i}'", ^{
+                [CDRTypeUtilities typeNameForEncoding:"^{a_tagged_struct=i}"] should equal(@"struct a_tagged_struct *");
+            });
+
+            it(@"should return the type name for '^i'", ^{
+                [CDRTypeUtilities typeNameForEncoding:"^i"] should equal(@"int *");
+            });
+
+            it(@"should return the type name for '^*'", ^{
+                [CDRTypeUtilities typeNameForEncoding:"^*"] should equal(@"char **");
+            });
+        });
+
+        context(@"with modifiers", ^{
+            it(@"should return the type name for 'r^i'", ^{
+                [CDRTypeUtilities typeNameForEncoding:"r^i"] should equal(@"const int *");
+            });
+
+            it(@"should return the type name for 'n^i'", ^{
+                [CDRTypeUtilities typeNameForEncoding:"n^i"] should equal(@"in int *");
+            });
+
+            it(@"should return the type name for 'N^i'", ^{
+                [CDRTypeUtilities typeNameForEncoding:"N^i"] should equal(@"inout int *");
+            });
+
+            it(@"should return the type name for 'o^i'", ^{
+                [CDRTypeUtilities typeNameForEncoding:"o^i"] should equal(@"out int *");
+            });
+
+            it(@"should return the type name for 'O^i'", ^{
+                [CDRTypeUtilities typeNameForEncoding:"O^i"] should equal(@"bycopy int *");
+            });
+
+            it(@"should return the type name for 'R^i'", ^{
+                [CDRTypeUtilities typeNameForEncoding:"R^i"] should equal(@"byref int *");
+            });
+
+            it(@"should return the type name for 'V^i'", ^{
+                [CDRTypeUtilities typeNameForEncoding:"V^i"] should equal(@"oneway int *");
+            });
+
+            it(@"should return the type name for 'RVr^i'", ^{
+                [CDRTypeUtilities typeNameForEncoding:"RVr^i"] should equal(@"byref oneway const int *");
+            });
+        });
+    });
+});
+
+SPEC_END

--- a/Spec/Doubles/CedarDoubleSharedExamples.mm
+++ b/Spec/Doubles/CedarDoubleSharedExamples.mm
@@ -378,9 +378,9 @@ sharedExamplesFor(@"a Cedar double", ^(NSDictionary *sharedContext) {
             });
 
             context(@"with a block that does not match the method's return type", ^{
-                void (^invalidBlock)(void) = ^{};
+                void (^invalidBlock)(NSString *) = ^(NSString *){};
                 it(@"should raise an exception", ^{
-                    ^{ myDouble stub_method("value").and_do_block(invalidBlock); } should raise_exception.with_reason([NSString stringWithFormat:@"Invalid return type '%s' instead of '%s' for <value>", @encode(void), @encode(size_t)]);
+                    ^{ myDouble stub_method("methodWithString:").and_do_block(invalidBlock); } should raise_exception.with_reason(@"Invalid return type 'void' instead of 'id' for <methodWithString:>");
                 });
             });
 
@@ -394,7 +394,7 @@ sharedExamplesFor(@"a Cedar double", ^(NSDictionary *sharedContext) {
             context(@"with a block that has a different argument type than the method", ^{
                 void (^invalidBlock)(float) = ^(float){};
                 it(@"should raise an exception", ^{
-                    ^{ myDouble stub_method("incrementBy:").and_do_block(invalidBlock); } should raise_exception.with_reason([NSString stringWithFormat:@"Found argument type '%s', expected '%s'; argument #1 for <incrementBy:>", @encode(float), @encode(size_t)]);
+                    ^{ myDouble stub_method("incrementByNumber:").and_do_block(invalidBlock); } should raise_exception.with_reason(@"Found argument type 'float', expected 'id'; argument #1 for <incrementByNumber:>");
                 });
             });
         });
@@ -651,7 +651,7 @@ sharedExamplesFor(@"a Cedar double", ^(NSDictionary *sharedContext) {
                     });
 
                     context(@"of incorrect types", ^{
-                        NSString *reason = @"Attempt to compare expected argument <10> with actual argument type @; argument #2 for <methodWithNumber1:andNumber2:>";
+                        NSString *reason = @"Attempt to compare expected argument <10> of type 'int' with actual argument type 'id'; argument #2 for <methodWithNumber1:andNumber2:>";
                         it(@"should raise an exception", ^{
                             int invalidInt = 10;
                             ^{ myDouble stub_method("methodWithNumber1:andNumber2:").with(arg1, invalidInt); } should raise_exception.with_reason(reason);
@@ -662,7 +662,7 @@ sharedExamplesFor(@"a Cedar double", ^(NSDictionary *sharedContext) {
 
             context(@"when specified with .with().and_with()", ^{
                 context(@"with too few", ^{
-                    size_t expectedIncrementValue = 1;
+                    unsigned int expectedIncrementValue = 1;
                     NSString *reason = [NSString stringWithFormat:@"Wrong number of expected parameters for <incrementByABit:andABitMore:>; expected: 1, actual: 2"];
 
                     it(@"should raise an exception", ^{
@@ -681,7 +681,7 @@ sharedExamplesFor(@"a Cedar double", ^(NSDictionary *sharedContext) {
                 context(@"with the correct number", ^{
                     NSNumber *expectedBitMoreValue = @10;
                     context(@"of the correct types", ^{
-                        size_t expectedIncrementValue = 1;
+                        unsigned int expectedIncrementValue = 1;
 
                         beforeEach(^{
                             myDouble stub_method("incrementByABit:andABitMore:").with(expectedIncrementValue).and_with(expectedBitMoreValue);
@@ -698,14 +698,14 @@ sharedExamplesFor(@"a Cedar double", ^(NSDictionary *sharedContext) {
                         context(@"where the incorrect type is an object", ^{
                             it(@"should raise an exception", ^{
                                 NSString *incorrectType = @"your mom";
-                                NSString *reason = [NSString stringWithFormat:@"Attempt to compare expected argument <%@> with actual argument type %s; argument #1 for <incrementByABit:andABitMore:>", @"your mom", @encode(size_t)];
+                                NSString *reason = [NSString stringWithFormat:@"Attempt to compare expected argument <%@> of type 'id' with actual argument type 'unsigned int'; argument #1 for <incrementByABit:andABitMore:>", incorrectType];
                                 ^{ myDouble stub_method("incrementByABit:andABitMore:").with(incorrectType).and_with(expectedBitMoreValue); } should raise_exception.with_reason(reason);
                             });
                         });
 
                         context(@"where the incorrect type is a char *", ^{
                             it(@"should raise an exception", ^{
-                                NSString *reason = [NSString stringWithFormat:@"Attempt to compare expected argument <cstring(%s)> with actual argument type %s; argument #1 for <incrementByABit:andABitMore:>", "your mom", @encode(size_t)];
+                                NSString *reason = [NSString stringWithFormat:@"Attempt to compare expected argument <cstring(%s)> of type 'char *' with actual argument type 'unsigned int'; argument #1 for <incrementByABit:andABitMore:>", "your mom"];
                                 ^{ myDouble stub_method("incrementByABit:andABitMore:").with((char *)"your mom").and_with(expectedBitMoreValue); } should raise_exception.with_reason(reason);
                             });
                         });
@@ -714,7 +714,7 @@ sharedExamplesFor(@"a Cedar double", ^(NSDictionary *sharedContext) {
                             it(@"should raise an exception", ^{
                                 int anInt = 1;
                                 int *ptr = &anInt;
-                                NSString *reason = [NSString stringWithFormat:@"Attempt to compare expected argument <%p> with actual argument type %s; argument #1 for <incrementByABit:andABitMore:>", ptr, @encode(size_t)];
+                                NSString *reason = [NSString stringWithFormat:@"Attempt to compare expected argument <%p> of type 'int *' with actual argument type 'unsigned int'; argument #1 for <incrementByABit:andABitMore:>", ptr];
                                 ^{ myDouble stub_method("incrementByABit:andABitMore:").with(ptr).and_with(expectedBitMoreValue); } should raise_exception.with_reason(reason);
                             });
                         });
@@ -849,7 +849,7 @@ sharedExamplesFor(@"a Cedar double", ^(NSDictionary *sharedContext) {
                 unsigned int invalidReturnValue = 3;
 
                 it(@"should raise an exception", ^{
-                    ^{ myDouble stub_method("value").and_return(invalidReturnValue); } should raise_exception.with_reason([NSString stringWithFormat:@"Invalid return value type '%s' instead of '%s' for <value>", @encode(unsigned int), @encode(size_t)]);
+                    ^{ myDouble stub_method("methodWithString:").and_return(invalidReturnValue); } should raise_exception.with_reason(@"Invalid return value type 'unsigned int' instead of 'id' for <methodWithString:>");
                 });
             });
         });

--- a/Spec/Support/SimpleIncrementer.h
+++ b/Spec/Support/SimpleIncrementer.h
@@ -20,7 +20,7 @@ typedef LargeIncrementerStruct (^ComplexIncrementerBlock)(NSNumber *, LargeIncre
 - (void)incrementBy:(size_t)amount;
 - (void)incrementByNumber:(NSNumber *)number;
 - (void)incrementByInteger:(NSUInteger)number;
-- (void)incrementByABit:(size_t)aBit andABitMore:(NSNumber *)aBitMore;
+- (void)incrementByABit:(unsigned int)aBit andABitMore:(NSNumber *)aBitMore;
 - (void)incrementWithException;
 - (void)methodWithBlock:(void(^)())blockArgument;
 - (void)methodWithCString:(char *)string;

--- a/Spec/Support/SimpleIncrementer.m
+++ b/Spec/Support/SimpleIncrementer.m
@@ -32,7 +32,7 @@
     self.value += integer;
 }
 
-- (void)incrementByABit:(size_t)aBit andABitMore:(NSNumber *)aBitMore {
+- (void)incrementByABit:(unsigned int)aBit andABitMore:(NSNumber *)aBitMore {
     self.value += aBit + [aBitMore intValue];
 }
 


### PR DESCRIPTION
This translates Objective-C type encodings into standard type name strings, which makes type-related failures during stubbing much easier to understand.

[#69669514]
