### PR TITLE
Fix travis ruby config and limit to supported SDKs

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,15 +1,12 @@
 language: objective-c
 
 rvm:
-  - "system; export CEDAR_SDK_VERSION=6.0 #"
-  - "system; export CEDAR_SDK_VERSION=6.1 #"
-  - "system; export CEDAR_SDK_VERSION=7.0 #"
+  - "2.1.1; export CEDAR_SDK_VERSION=6.1 #"
+  - "2.1.1; export CEDAR_SDK_VERSION=7.0 #"
+  - "2.1.1; export CEDAR_SDK_VERSION=7.1 #"
 
 env:
   matrix:
-    - CEDAR_SDK_RUNTIME_VERSION="5.0"
-    - CEDAR_SDK_RUNTIME_VERSION="5.1"
-    - CEDAR_SDK_RUNTIME_VERSION="6.0"
     - CEDAR_SDK_RUNTIME_VERSION="6.1"
     - CEDAR_SDK_RUNTIME_VERSION="7.0"
 


### PR DESCRIPTION
Specifying a 2.0 or 1.9 ruby version seems to yield a broken RVM
environment on Travis CI right now, but 2.1.1 works.  The previous
commit worked around this, but it felt like more of a hack.

Running on SDK 7.1 is also removed since iOSSpecs launched from the
command line is currently broken.

See: http://blog.travis-ci.com/2014-04-15-xcode-51-ios-71-osx-109/
