### PR TITLE
Rakefile bugfixes

### DIFF
--- a/CodeSnippetsAndTemplates/Templates/File Templates/Cedar/Cedar Spec.xctemplate/TemplateInfo.plist
+++ b/CodeSnippetsAndTemplates/Templates/File Templates/Cedar/Cedar Spec.xctemplate/TemplateInfo.plist
@@ -40,5 +40,7 @@
 	<string>1</string>
 	<key>Summary</key>
 	<string>A Cedar Spec</string>
+	<key>isCedarTemplate</key>
+	<true/>
 </dict>
 </plist>

--- a/CodeSnippetsAndTemplates/Templates/Project Templates/Cedar/Cedar Example Spec.xctemplate/TemplateInfo.plist
+++ b/CodeSnippetsAndTemplates/Templates/Project Templates/Cedar/Cedar Example Spec.xctemplate/TemplateInfo.plist
@@ -24,5 +24,7 @@
 			<string>ExampleSpec.mm</string>
 		</dict>
 	</dict>
+	<key>isCedarTemplate</key>
+	<true/>
 </dict>
 </plist>

--- a/CodeSnippetsAndTemplates/Templates/Project Templates/Cedar/Cedar Testing Bundle.xctemplate/TemplateInfo.plist
+++ b/CodeSnippetsAndTemplates/Templates/Project Templates/Cedar/Cedar Testing Bundle.xctemplate/TemplateInfo.plist
@@ -60,5 +60,7 @@
 &lt;string&gt;????&lt;/string&gt;
 </string>
 	</dict>
+	<key>isCedarTemplate</key>
+	<true/>
 </dict>
 </plist>

--- a/CodeSnippetsAndTemplates/Templates/Project Templates/Cedar/Disable ARC Explicitly.xctemplate/TemplateInfo.plist
+++ b/CodeSnippetsAndTemplates/Templates/Project Templates/Cedar/Disable ARC Explicitly.xctemplate/TemplateInfo.plist
@@ -36,5 +36,7 @@
 			</dict>
 		</dict>
 	</array>
+	<key>isCedarTemplate</key>
+	<true/>
 </dict>
 </plist>

--- a/CodeSnippetsAndTemplates/Templates/Project Templates/Cedar/OS X Cedar Spec Suite.xctemplate/TemplateInfo.plist
+++ b/CodeSnippetsAndTemplates/Templates/Project Templates/Cedar/OS X Cedar Spec Suite.xctemplate/TemplateInfo.plist
@@ -89,5 +89,7 @@
 		<string>#import &lt;Foundation/Foundation.h&gt;
 </string>
 	</dict>
+	<key>isCedarTemplate</key>
+	<true/>
 </dict>
 </plist>

--- a/CodeSnippetsAndTemplates/Templates/Project Templates/Cedar/OS X Cedar Testing Bundle.xctemplate/TemplateInfo.plist
+++ b/CodeSnippetsAndTemplates/Templates/Project Templates/Cedar/OS X Cedar Testing Bundle.xctemplate/TemplateInfo.plist
@@ -90,5 +90,7 @@
 		<string>___PACKAGENAME___-Prefix.pch:objC:importCedar</string>
 		<string>Frameworks/Cedar.framework</string>
 	</array>
+	<key>isCedarTemplate</key>
+	<true/>
 </dict>
 </plist>

--- a/CodeSnippetsAndTemplates/Templates/Project Templates/Cedar/iOS Cedar Spec Suite.xctemplate/TemplateInfo.plist
+++ b/CodeSnippetsAndTemplates/Templates/Project Templates/Cedar/iOS Cedar Spec Suite.xctemplate/TemplateInfo.plist
@@ -167,5 +167,7 @@
 	</array>
 	<key>Description</key>
 	<string>Creates an iOS application which runs Cedar specs.</string>
+	<key>isCedarTemplate</key>
+	<true/>
 </dict>
 </plist>

--- a/CodeSnippetsAndTemplates/Templates/Project Templates/Cedar/iOS Cedar Testing Bundle.xctemplate/TemplateInfo.plist
+++ b/CodeSnippetsAndTemplates/Templates/Project Templates/Cedar/iOS Cedar Testing Bundle.xctemplate/TemplateInfo.plist
@@ -128,5 +128,7 @@
 			</dict>
 		</dict>
 	</array>
+	<key>isCedarTemplate</key>
+	<true/>
 </dict>
 </plist>


### PR DESCRIPTION
Here are a few improvements to the Rakefile:
- Improve validation of the framework path argument to `rake upgrade` and report better errors when it is used incorrectly [#64936304]
- Improve cleanup of existing templates when installing, to make sure obsolete/renamed ones don't linger [#64936380]
- On the other hand, don't remove templates that are determined to not belong to Cedar. This is determined  by looking for a `isCedarTemplate => "true"` entry in the template's plist (snippets are already handled this way). For now, it is also looking for an `Identifier` entry that begins with `com.pivotallabs.cedar` to handle upgrades from templates that don't yet have the new key. Eventually this latter case can probably be removed. [#68661790]
