### PR TITLE
Improve handling of object-typed nil values during argument matching

### DIFF
--- a/Source/Headers/Matchers/Base/Equal.h
+++ b/Source/Headers/Matchers/Base/Equal.h
@@ -20,6 +20,9 @@ namespace Cedar { namespace Matchers {
         virtual NSString * failure_message_end() const;
 
     private:
+        void validate_not_nil() const;
+
+    private:
         const T & expectedValue_;
     };
 
@@ -45,7 +48,16 @@ namespace Cedar { namespace Matchers {
 
     template<typename T> template<typename U>
     bool Equal<T>::matches(const U & actualValue) const {
+        this->validate_not_nil();
         return Comparators::compare_equal(actualValue, expectedValue_);
+    }
+
+#pragma mark - Private interface
+    template<typename T>
+    void Equal<T>::validate_not_nil() const {
+        if (0 == strncmp(@encode(T), "@", 1) && [[NSValue value:&expectedValue_ withObjCType:@encode(T)] nonretainedObjectValue] == nil) {
+            [[CDRSpecFailure specFailureWithReason:@"Unexpected use of equal matcher to check for nil; use the be_nil matcher to match nil values"] raise];
+        }
     }
 
 #pragma mark equality operators

--- a/Source/Headers/Matchers/Comparators/CompareEqual.h
+++ b/Source/Headers/Matchers/Comparators/CompareEqual.h
@@ -14,7 +14,7 @@ namespace Cedar { namespace Matchers { namespace Comparators {
 
 #pragma mark NSNumber
     inline bool compare_equal(NSNumber * const actualValue, NSNumber * const expectedValue) {
-        return [actualValue isEqualToNumber:expectedValue];
+        return expectedValue ? [actualValue isEqualToNumber:expectedValue] : false;
     }
 
     inline bool compare_equal(NSNumber * const actualValue, const id expectedValue) {

--- a/Source/Headers/Matchers/Stringifiers/StringifiersBase.h
+++ b/Source/Headers/Matchers/Stringifiers/StringifiersBase.h
@@ -28,6 +28,9 @@ namespace Cedar { namespace Matchers { namespace Stringifiers {
     }
 
     inline NSString * string_for(NSNumber * const value) {
+        if (!value) {
+            return [NSString stringWithFormat:@"%@", value];
+        }
         return string_for([value floatValue]);
     }
 

--- a/Source/Matchers/Stringifiers/StringifiersBase.mm
+++ b/Source/Matchers/Stringifiers/StringifiersBase.mm
@@ -9,7 +9,7 @@ namespace Cedar { namespace Matchers { namespace Stringifiers {
         if (object && class_getInstanceMethod(klass, @selector(description)) == NULL) {
             return [NSString stringWithFormat:@"%@ %p", NSStringFromClass(klass), object];
         } else {
-            return [[valueId nonretainedObjectValue] description];
+            return [NSString stringWithFormat:@"%@", [[valueId nonretainedObjectValue] description]];
         }
     }
 }}}

--- a/Spec/Doubles/CedarDoubleSharedExamples.mm
+++ b/Spec/Doubles/CedarDoubleSharedExamples.mm
@@ -760,6 +760,30 @@ sharedExamplesFor(@"a Cedar double", ^(NSDictionary *sharedContext) {
                     });
                 });
 
+                context(@"with id-typed nil", ^{
+                    __block BOOL stubbedBehaviorWasInvoked;
+                    beforeEach(^{
+                        stubbedBehaviorWasInvoked = NO;
+                        myDouble stub_method("incrementByNumber:").with((id)nil).and_do(^(NSInvocation *) {
+                            stubbedBehaviorWasInvoked = YES;
+                        });
+                    });
+
+                    context(@"when invoked with a nil argument", ^{
+                        beforeEach(^{
+                            [myDouble incrementByNumber:nil];
+                        });
+
+                        it(@"should record the invocation", ^{
+                            myDouble should have_received("incrementByNumber:").with((id)nil);
+                        });
+
+                        it(@"should invoke the stubbed behavior", ^{
+                            stubbedBehaviorWasInvoked should be_truthy;
+                        });
+                    });
+                });
+
                 context(@"with an argument specified as anything", ^{
                     NSNumber *arg1 = @3;
                     NSNumber *arg2 = @123;

--- a/Spec/Doubles/HaveReceivedSpec.mm
+++ b/Spec/Doubles/HaveReceivedSpec.mm
@@ -286,6 +286,54 @@ describe(@"have_received matcher", ^{
                     });
                 });
             });
+
+            context(@"with an incorrect expected parameter that is nil", ^{
+                context(@"that is typed as a number", ^{
+                    NSNumber *expectedParameter = nil;
+
+                    describe(@"positive match", ^{
+                        it(@"should fail with a sensible failure message", ^{
+                            expectFailureWithMessage([NSString stringWithFormat:@"Expected <%@> to have received message <%@>, with arguments: <%@>", incrementer, NSStringFromSelector(method), expectedParameter], ^{
+                                expect(incrementer).to(have_received(method).with(expectedParameter));
+                            });
+
+                            expectFailureWithMessage([NSString stringWithFormat:@"Expected <%@> to have received message <%@>, with arguments: <%@>", incrementer, NSStringFromSelector(method), expectedParameter], ^{
+                                expect(incrementer).to(have_received("incrementByNumber:").with(expectedParameter));
+                            });
+                        });
+                    });
+
+                    describe(@"negative match", ^{
+                        it(@"should pass", ^{
+                            expect(incrementer).to_not(have_received(method).with(expectedParameter));
+                            expect(incrementer).to_not(have_received("incrementByNumber:").with(expectedParameter));
+                        });
+                    });
+                });
+
+                context(@"that is typed as id", ^{
+                    id expectedParameter = nil;
+
+                    describe(@"positive match", ^{
+                        it(@"should fail with a sensible failure message", ^{
+                            expectFailureWithMessage([NSString stringWithFormat:@"Expected <%@> to have received message <%@>, with arguments: <%@>", incrementer, NSStringFromSelector(method), expectedParameter], ^{
+                                expect(incrementer).to(have_received(method).with(expectedParameter));
+                            });
+
+                            expectFailureWithMessage([NSString stringWithFormat:@"Expected <%@> to have received message <%@>, with arguments: <%@>", incrementer, NSStringFromSelector(method), expectedParameter], ^{
+                                expect(incrementer).to(have_received("incrementByNumber:").with(expectedParameter));
+                            });
+                        });
+                    });
+
+                    describe(@"negative match", ^{
+                        it(@"should pass", ^{
+                            expect(incrementer).to_not(have_received(method).with(expectedParameter));
+                            expect(incrementer).to_not(have_received("incrementByNumber:").with(expectedParameter));
+                        });
+                    });
+                });
+            });
         });
 
         context(@"which has not been called", ^{

--- a/Spec/Matchers/Base/BeNilSpec.mm
+++ b/Spec/Matchers/Base/BeNilSpec.mm
@@ -103,6 +103,50 @@ describe(@"be_nil matcher", ^{
         });
     });
 
+    describe(@"when the value is a block", ^{
+        __block void(^value)(void);
+
+        describe(@"which is nil", ^{
+            beforeEach(^{
+                value = nil;
+            });
+
+            describe(@"positive match", ^{
+                it(@"should should pass", ^{
+                    expect(value).to(be_nil());
+                });
+            });
+
+            describe(@"negative match", ^{
+                it(@"should fail with a sensible failure message", ^{
+                    expectFailureWithMessage(@"Expected <nil> to not be nil", ^{
+                        expect(value).to_not(be_nil());
+                    });
+                });
+            });
+        });
+
+        describe(@"which is not nil", ^{
+            beforeEach(^{
+                value = ^{};
+            });
+
+            describe(@"positive match", ^{
+                it(@"should fail with a sensible failure message", ^{
+                    expectFailureWithMessage([NSString stringWithFormat:@"Expected <%p> to be nil", value], ^{
+                        expect(value).to(be_nil());
+                    });
+                });
+            });
+
+            describe(@"negative match", ^{
+                it(@"should should pass", ^{
+                    expect(value).to_not(be_nil());
+                });
+            });
+        });
+    });
+
     describe(@"when the value is not a pointer", ^{
         int value = 7;
 

--- a/Spec/Matchers/Base/BeNil_ARCSpec.mm
+++ b/Spec/Matchers/Base/BeNil_ARCSpec.mm
@@ -148,6 +148,50 @@ describe(@"be_nil matcher (under ARC)", ^{
         });
     });
 
+    describe(@"when the value is a block", ^{
+        __block void(^value)(void);
+
+        describe(@"which is nil", ^{
+            beforeEach(^{
+                value = nil;
+            });
+
+            describe(@"positive match", ^{
+                it(@"should should pass", ^{
+                    expect(value).to(be_nil());
+                });
+            });
+
+            describe(@"negative match", ^{
+                it(@"should fail with a sensible failure message", ^{
+                    expectFailureWithMessage(@"Expected <nil> to not be nil", ^{
+                        expect(value).to_not(be_nil());
+                    });
+                });
+            });
+        });
+
+        describe(@"which is not nil", ^{
+            beforeEach(^{
+                value = ^{};
+            });
+
+            describe(@"positive match", ^{
+                it(@"should fail with a sensible failure message", ^{
+                    expectFailureWithMessage([NSString stringWithFormat:@"Expected <%p> to be nil", value], ^{
+                        expect(value).to(be_nil());
+                    });
+                });
+            });
+
+            describe(@"negative match", ^{
+                it(@"should should pass", ^{
+                    expect(value).to_not(be_nil());
+                });
+            });
+        });
+    });
+
     describe(@"when the value is not a pointer", ^{
         int value = 7;
 

--- a/Spec/Matchers/Base/EqualSpec.mm
+++ b/Spec/Matchers/Base/EqualSpec.mm
@@ -358,6 +358,29 @@ describe(@"equal matcher", ^{
                     });
                 });
             });
+
+            describe(@"and the values are nil", ^{
+                id actualValue = nil;
+                beforeEach(^{
+                    expectedValue = nil;
+                });
+
+                describe(@"positive match", ^{
+                    it(@"should fail with a sensible failure message", ^{
+                        expectFailureWithMessage(@"Unexpected use of equal matcher to check for nil; use the be_nil matcher to match nil values", ^{
+                            expect(actualValue).to(equal(expectedValue));
+                        });
+                    });
+                });
+
+                describe(@"negative match", ^{
+                    it(@"should fail with a sensible failure message", ^{
+                        expectFailureWithMessage(@"Unexpected use of equal matcher to check for nil; use the be_nil matcher to match nil values", ^{
+                            expect(actualValue).to(equal(expectedValue));
+                        });
+                    });
+                });
+            });
         });
 
         describe(@"and the expected value is also declared as an id", ^{
@@ -402,6 +425,30 @@ describe(@"equal matcher", ^{
                     });
                 });
             });
+
+            describe(@"and the values are nil", ^{
+                id actualValue = nil;
+                beforeEach(^{
+                    expectedValue = nil;
+                });
+
+                describe(@"positive match", ^{
+                    it(@"should fail with a sensible failure message", ^{
+                        expectFailureWithMessage(@"Unexpected use of equal matcher to check for nil; use the be_nil matcher to match nil values", ^{
+                            expect(actualValue).to(equal(expectedValue));
+                        });
+                    });
+                });
+
+                describe(@"negative match", ^{
+                    it(@"should fail with a sensible failure message", ^{
+                        expectFailureWithMessage(@"Unexpected use of equal matcher to check for nil; use the be_nil matcher to match nil values", ^{
+                            expect(actualValue).to(equal(expectedValue));
+                        });
+                    });
+                });
+            });
+
         });
 
         describe(@"and the expected value is declared as an NSNumber *", ^{
@@ -583,6 +630,29 @@ describe(@"equal matcher", ^{
                     });
                 });
             });
+
+            describe(@"and the values are nil", ^{
+                NSObject *actualValue = nil;
+                beforeEach(^{
+                    expectedValue = nil;
+                });
+
+                describe(@"positive match", ^{
+                    it(@"should fail with a sensible failure message", ^{
+                        expectFailureWithMessage(@"Unexpected use of equal matcher to check for nil; use the be_nil matcher to match nil values", ^{
+                            expect(actualValue).to(equal(expectedValue));
+                        });
+                    });
+                });
+
+                describe(@"negative match", ^{
+                    it(@"should fail with a sensible failure message", ^{
+                        expectFailureWithMessage(@"Unexpected use of equal matcher to check for nil; use the be_nil matcher to match nil values", ^{
+                            expect(actualValue).to(equal(expectedValue));
+                        });
+                    });
+                });
+            });
         });
 
         describe(@"and the expected value is declared as an id", ^{
@@ -624,6 +694,29 @@ describe(@"equal matcher", ^{
                 describe(@"negative match", ^{
                     it(@"should pass", ^{
                         expect(actualValue).to_not(equal(expectedValue));
+                    });
+                });
+            });
+
+            describe(@"and the values are nil", ^{
+                NSObject *actualValue = nil;
+                beforeEach(^{
+                    expectedValue = nil;
+                });
+
+                describe(@"positive match", ^{
+                    it(@"should fail with a sensible failure message", ^{
+                        expectFailureWithMessage(@"Unexpected use of equal matcher to check for nil; use the be_nil matcher to match nil values", ^{
+                            expect(actualValue).to(equal(expectedValue));
+                        });
+                    });
+                });
+
+                describe(@"negative match", ^{
+                    it(@"should fail with a sensible failure message", ^{
+                        expectFailureWithMessage(@"Unexpected use of equal matcher to check for nil; use the be_nil matcher to match nil values", ^{
+                            expect(actualValue).to(equal(expectedValue));
+                        });
                     });
                 });
             });
@@ -1300,6 +1393,28 @@ describe(@"equal matcher", ^{
                 describe(@"negative match", ^{
                     it(@"should pass", ^{
                         expect(actualValue).to_not(equal(expectedValue));
+                    });
+                });
+
+                describe(@"and the expected value is nil", ^{
+                    beforeEach(^{
+                        expectedValue = nil;
+                    });
+
+                    describe(@"positive match", ^{
+                        it(@"should fail with a sensible failure message", ^{
+                            expectFailureWithMessage(@"Unexpected use of equal matcher to check for nil; use the be_nil matcher to match nil values", ^{
+                                expect(actualValue).to(equal(expectedValue));
+                            });
+                        });
+                    });
+
+                    describe(@"negative match", ^{
+                        it(@"should fail with a sensible failure message", ^{
+                            expectFailureWithMessage(@"Unexpected use of equal matcher to check for nil; use the be_nil matcher to match nil values", ^{
+                                expect(actualValue).to(equal(expectedValue));
+                            });
+                        });
                     });
                 });
             });


### PR DESCRIPTION
The existing tests around the usage of nil generally use a simple `nil` literal, which seems to be treated as type `int` by the compiler. I've fixed behavior and crashes around the usage of nil which is typed as `id`.
