### PR TITLE
Cedar.h imports SpecHelper to make it behave more as expected

### DIFF
--- a/Source/Headers/Cedar.h
+++ b/Source/Headers/Cedar.h
@@ -1,1 +1,2 @@
 #import "CDRFunctions.h"
+#import "SpecHelper.h"


### PR DESCRIPTION
As per the CocoaPods installation instructions on the wiki, spec files need to add the line `#import <Cedar-iOS/SpecHelper.h>` to use Cedar. However there is a general expectation that to use a library, you import a header with the same name. This change allows for `#import <Cedar-iOS/Cedar-iOS.h>` which will reduce confusion.
