### PR TITLE
Setup the Podspec to explicitly link against libc++

### DIFF
--- a/Cedar.podspec
+++ b/Cedar.podspec
@@ -21,5 +21,6 @@ Pod::Spec.new do |s|
     'CLANG_CXX_LANGUAGE_STANDARD' => 'c++0x',
     'CLANG_CXX_LIBRARY' => 'libc++'
   }
+  s.libraries = 'c++'
 
 end


### PR DESCRIPTION
This fixes linker errors that I was observing when first trying to run tests after doing a standard Cedar setup via CocoaPods using Xcode 5.1.1 on Mavericks.

[#69776032]
