### PR TITLE
Stubs can return types that don't have compare_equals or a stringifier

### DIFF
--- a/Source/Doubles/StubbedMethod.mm
+++ b/Source/Doubles/StubbedMethod.mm
@@ -11,7 +11,7 @@ namespace Cedar { namespace Doubles {
     StubbedMethod::StubbedMethod(const char * method_name) : InvocationMatcher(sel_registerName(method_name)), exception_to_raise_(0), invocation_block_(0), implementation_block_(0) {}
     StubbedMethod::StubbedMethod(const StubbedMethod &rhs)
     : InvocationMatcher(rhs)
-    , return_value_argument_(rhs.return_value_argument_)
+    , return_value_(rhs.return_value_)
     , invocation_block_([rhs.invocation_block_ retain])
     , implementation_block_([rhs.implementation_block_ retain])
     , exception_to_raise_(rhs.exception_to_raise_) {}

--- a/Source/Headers/Doubles/Arguments/ReturnValue.h
+++ b/Source/Headers/Doubles/Arguments/ReturnValue.h
@@ -2,26 +2,54 @@
 
 namespace Cedar { namespace Doubles {
 
+    class ReturnValue {
+    public:
+        virtual ~ReturnValue() = 0;
+
+        virtual const char * const value_encoding() const = 0;
+        virtual void * value_bytes() const = 0;
+        virtual bool matches_encoding(const char *) const = 0;
+
+        typedef std::shared_ptr<ReturnValue> shared_ptr_t;
+    };
+
+    inline /* virtual */ ReturnValue::~ReturnValue() {}
+
     template<typename T>
-    class ReturnValue : public ValueArgument<T> {
+    class TypedReturnValue : public ReturnValue {
     private:
-        ReturnValue & operator=(const ReturnValue &);
+        TypedReturnValue<T> & operator=(const TypedReturnValue<T> &);
 
     public:
-        explicit ReturnValue(const T &);
-        virtual ~ReturnValue();
+        explicit TypedReturnValue(const T &);
+        virtual ~TypedReturnValue();
 
+        virtual const char * const value_encoding() const;
+        virtual void * value_bytes() const;
         virtual bool matches_encoding(const char *) const;
+
+    private:
+        const T value_;
     };
 
     template<typename T>
-    ReturnValue<T>::ReturnValue(const T & value) : ValueArgument<T>(value) {}
+    TypedReturnValue<T>::TypedReturnValue(const T & value) : value_(value) {}
 
     template<typename T>
-    /* virtual */ ReturnValue<T>::~ReturnValue() {}
+    /* virtual */ TypedReturnValue<T>::~TypedReturnValue() {}
 
     template<typename T>
-    /* virtual */ bool ReturnValue<T>::matches_encoding(const char * actual_argument_encoding) const {
+    /* virtual */ const char * const TypedReturnValue<T>::value_encoding() const {
+        return @encode(T);
+    }
+
+    template<typename T>
+    /* virtual */ void * TypedReturnValue<T>::value_bytes() const {
+        return (const_cast<T *>(&value_));
+    }
+
+    template<typename T>
+    /* virtual */ bool TypedReturnValue<T>::matches_encoding(const char * actual_argument_encoding) const {
         return 0 == strcmp(@encode(T), actual_argument_encoding);
     }
 

--- a/Source/Headers/Doubles/StubbedMethod.h
+++ b/Source/Headers/Doubles/StubbedMethod.h
@@ -41,7 +41,7 @@ namespace Cedar { namespace Doubles {
         StubbedMethod & and_raise_exception();
         StubbedMethod & and_raise_exception(NSObject * exception);
 
-        Argument & return_value() const { return *return_value_argument_; };
+        ReturnValue & return_value() const { return *return_value_; };
 
         struct SelCompare {
             bool operator() (const SEL& lhs, const SEL& rhs) const {
@@ -62,7 +62,7 @@ namespace Cedar { namespace Doubles {
         unsigned int arguments_specificity_ranking() const;
 
     private:
-        bool has_return_value() const { return return_value_argument_.get(); };
+        bool has_return_value() const { return return_value_.get(); };
         bool has_invocation_block() const { return invocation_block_; }
         bool has_implementation_block() const { return implementation_block_; }
 
@@ -73,7 +73,7 @@ namespace Cedar { namespace Doubles {
         void raise_for_multiple_return_values() const;
         void raise_for_multiple_blocks() const;
     private:
-        Argument::shared_ptr_t return_value_argument_;
+        ReturnValue::shared_ptr_t return_value_;
         invocation_block_t invocation_block_;
         implementation_block_t implementation_block_;
         NSObject * exception_to_raise_;
@@ -87,7 +87,7 @@ namespace Cedar { namespace Doubles {
             this->raise_for_multiple_return_values();
         }
 
-        return_value_argument_ = Argument::shared_ptr_t(new ReturnValue<T>(return_value));
+        return_value_ = ReturnValue::shared_ptr_t(new TypedReturnValue<T>(return_value));
         return *this;
     }
 

--- a/Spec/Doubles/CedarDoubleSharedExamples.mm
+++ b/Spec/Doubles/CedarDoubleSharedExamples.mm
@@ -852,6 +852,18 @@ sharedExamplesFor(@"a Cedar double", ^(NSDictionary *sharedContext) {
                     ^{ myDouble stub_method("value").and_return(invalidReturnValue); } should raise_exception.with_reason([NSString stringWithFormat:@"Invalid return value type '%s' instead of '%s' for <value>", @encode(unsigned int), @encode(size_t)]);
                 });
             });
+
+            context(@"with an arbitrary struct value", ^{
+                LargeIncrementerStruct returnValue = {99, 88, 77, 66};
+                beforeEach(^{
+                    myDouble stub_method("methodWithLargeStruct1:andLargeStruct2:").and_return(returnValue);
+                });
+
+                it(@"should return the expected value", ^{
+                    LargeIncrementerStruct returnedValue = [myDouble methodWithLargeStruct1:{} andLargeStruct2:{}];
+                    memcmp(&returnValue, &returnedValue, sizeof(LargeIncrementerStruct)) should equal(0);
+                });
+            });
         });
     });
 });


### PR DESCRIPTION
- ReturnValue is no longer a ValueArgument subclass, which brought along unwanted behaviors

[#39969975, #65424036]
