### PR TITLE
Release spec blocks after execution

### DIFF
--- a/Source/CDRExample.m
+++ b/Source/CDRExample.m
@@ -52,7 +52,7 @@ const CDRSpecBlock PENDING = nil;
 }
 
 - (BOOL)isPending {
-    return block_ == nil;
+    return (self.state == CDRExampleStateIncomplete && block_ == nil) || self.state == CDRExampleStatePending;
 }
 
 - (void)runWithDispatcher:(CDRReportDispatcher *)dispatcher {
@@ -99,6 +99,9 @@ const CDRSpecBlock PENDING = nil;
     endDate_ = [[NSDate alloc] init];
 
     [dispatcher runDidFinishExample:self];
+
+    [block_ release];
+    block_ = nil;
 }
 
 #pragma mark Private interface

--- a/Source/CDRExampleGroup.m
+++ b/Source/CDRExampleGroup.m
@@ -118,6 +118,10 @@
     [endDate_ release];
     endDate_ = [[NSDate alloc] init];
     [dispatcher runDidFinishExampleGroup:self];
+
+    [beforeBlocks_ release]; beforeBlocks_ = nil;
+    [afterBlocks_ release]; afterBlocks_ = nil;
+    self.subjectActionBlock = nil;
 }
 
 - (BOOL)hasFocusedExamples {

--- a/Spec/CDRExampleSpec.mm
+++ b/Spec/CDRExampleSpec.mm
@@ -14,6 +14,7 @@
 #import "SimpleKeyValueObserver.h"
 #import "FibonacciCalculator.h"
 #import "CDRReportDispatcher.h"
+#import <objc/runtime.h>
 
 using namespace Cedar::Matchers;
 using namespace Cedar::Doubles;
@@ -151,15 +152,26 @@ describe(@"CDRExample", ^{
 
     describe(@"runWithDispatcher:", ^{
         __block CDRReportDispatcher *dispatcher;
+        __block __weak id weakCapturedObject;
+
         beforeEach(^{
             dispatcher = nice_fake_for([CDRReportDispatcher class]);
         });
 
         beforeEach(^{
+            NSString *capturedObject = [@"abc" mutableCopy];
+            objc_storeWeak(&weakCapturedObject, capturedObject);
+
             example = [[[CDRExample alloc] initWithText:exampleText andBlock:^{
                 // so we don't get a zero-value for runTime
                 [NSThread sleepForTimeInterval:0.01];
+                [capturedObject length];
             }] autorelease];
+
+            [capturedObject release]; capturedObject = nil;
+            @autoreleasepool {
+                objc_loadWeak(&weakCapturedObject) should_not be_nil;
+            }
 
             // assert example is populated at the appropriate times
             dispatcher stub_method(@selector(runWillStartExample:)).and_do(^(NSInvocation *invocation) {
@@ -190,6 +202,10 @@ describe(@"CDRExample", ^{
             it(@"should fail", ^{
                 ^{ [example runWithDispatcher:dispatcher]; } should raise_exception.with_reason([NSString stringWithFormat:@"Attempt to run example twice: %@", [example fullText]]);
             });
+        });
+
+        it(@"should allow captured objects to be deallocated once it has finished running", ^{
+            objc_loadWeak(&weakCapturedObject) should be_nil;
         });
     });
 
@@ -515,6 +531,45 @@ describe(@"CDRExample", ^{
             it(@"should return the description of whatever was thrown", ^{
                 NSString *message = example.message;
                 expect(message).to(equal(failureMessage));
+            });
+        });
+    });
+
+    describe(@"isPending", ^{
+        context(@"for an example with a block", ^{
+            it(@"should not report itself as pending", ^{
+                [example isPending] should be_falsy;
+            });
+
+            context(@"after it has run", ^{
+                beforeEach(^{
+                    [example runWithDispatcher:dispatcher];
+                });
+
+                it(@"should not report itself as pending", ^{
+                    [example isPending] should be_falsy;
+                });
+            });
+
+        });
+
+        context(@"for a pending example", ^{
+            beforeEach(^{
+                example = [[[CDRExample alloc] initWithText:@"I should be pending" andBlock:PENDING] autorelease];
+            });
+
+            it(@"should report itself as pending", ^{
+                [example isPending] should be_truthy;
+            });
+
+            context(@"after it has run", ^{
+                beforeEach(^{
+                    [example runWithDispatcher:dispatcher];
+                });
+
+                it(@"should report itself as pending", ^{
+                    [example isPending] should be_truthy;
+                });
             });
         });
     });


### PR DESCRIPTION
This allows objects created during the execution of an example group to be released as soon as the group has finished running, instead of hanging around until the end of the entire spec run.

This does require adding the constraint that examples/groups are only allowed to run a single time, although I think that is problematic.

[#66016196]
