### PR TITLE
Fix spies leaking

### DIFF
--- a/Cedar.xcodeproj/project.pbxproj
+++ b/Cedar.xcodeproj/project.pbxproj
@@ -75,6 +75,8 @@
 		22B6A22715B7ACF800960ADE /* InvocationMatcher.h in Copy headers to framework */ = {isa = PBXBuildFile; fileRef = AE597B4015B0638B00EEF305 /* InvocationMatcher.h */; };
 		22FB7B4416ACBB3A00012D69 /* HeadlessSimulatorWorkaround.m in Sources */ = {isa = PBXBuildFile; fileRef = 22FB7B4316ACBB3A00012D69 /* HeadlessSimulatorWorkaround.m */; };
 		342F5D0B18F430DB00F38E35 /* QuartzCore.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 342F5D0A18F430DB00F38E35 /* QuartzCore.framework */; };
+		343FAFEA190FDAEC0085AFEC /* DeallocNotifier.m in Sources */ = {isa = PBXBuildFile; fileRef = 343FAFE9190FDAEC0085AFEC /* DeallocNotifier.m */; };
+		343FAFEB190FDAEC0085AFEC /* DeallocNotifier.m in Sources */ = {isa = PBXBuildFile; fileRef = 343FAFE9190FDAEC0085AFEC /* DeallocNotifier.m */; };
 		34681C2C18FE451E009D38AC /* CDRTypeUtilities.m in Sources */ = {isa = PBXBuildFile; fileRef = 34681C2B18FE451E009D38AC /* CDRTypeUtilities.m */; };
 		34681C2E18FE4884009D38AC /* CDRTypeUtilities.m in Sources */ = {isa = PBXBuildFile; fileRef = 34681C2B18FE451E009D38AC /* CDRTypeUtilities.m */; };
 		34681C3018FE4B68009D38AC /* CDRTypeUtilitiesSpec.mm in Sources */ = {isa = PBXBuildFile; fileRef = 34681C2F18FE4B68009D38AC /* CDRTypeUtilitiesSpec.mm */; };
@@ -82,6 +84,7 @@
 		34ADE41818F23C8E00BD1E99 /* NSMethodSignature+Cedar.m in Sources */ = {isa = PBXBuildFile; fileRef = 34ADE41618F23C8E00BD1E99 /* NSMethodSignature+Cedar.m */; };
 		34ADE41918F23E6B00BD1E99 /* NSMethodSignature+Cedar.m in Sources */ = {isa = PBXBuildFile; fileRef = 34ADE41618F23C8E00BD1E99 /* NSMethodSignature+Cedar.m */; };
 		34D4B5C318F3AE0400FB2C3B /* UIKitContainSpec.mm in Sources */ = {isa = PBXBuildFile; fileRef = 34D4B5C118F3ADFF00FB2C3B /* UIKitContainSpec.mm */; };
+		34D93AD51911441300200C71 /* DeallocNotifier.m in Sources */ = {isa = PBXBuildFile; fileRef = 343FAFE9190FDAEC0085AFEC /* DeallocNotifier.m */; };
 		34EBFD0F18FF505F005392AB /* UIKitComparatorsContainer.h in Copy headers to framework */ = {isa = PBXBuildFile; fileRef = 34D4B5C418F3B68900FB2C3B /* UIKitComparatorsContainer.h */; };
 		42064466139B44EC00C85605 /* CDRTeamCityReporter.h in Headers */ = {isa = PBXBuildFile; fileRef = 42064465139B44EC00C85605 /* CDRTeamCityReporter.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		42064467139B44EC00C85605 /* CDRTeamCityReporter.h in Headers */ = {isa = PBXBuildFile; fileRef = 42064465139B44EC00C85605 /* CDRTeamCityReporter.h */; };
@@ -626,6 +629,8 @@
 		22FB7B4016ACBA5900012D69 /* HeadlessSimulatorWorkaround.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = HeadlessSimulatorWorkaround.h; sourceTree = "<group>"; };
 		22FB7B4316ACBB3A00012D69 /* HeadlessSimulatorWorkaround.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = HeadlessSimulatorWorkaround.m; sourceTree = "<group>"; };
 		342F5D0A18F430DB00F38E35 /* QuartzCore.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = QuartzCore.framework; path = Platforms/iPhoneOS.platform/Developer/SDKs/iPhoneOS7.1.sdk/System/Library/Frameworks/QuartzCore.framework; sourceTree = DEVELOPER_DIR; };
+		343FAFE8190FDAEC0085AFEC /* DeallocNotifier.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = DeallocNotifier.h; sourceTree = "<group>"; };
+		343FAFE9190FDAEC0085AFEC /* DeallocNotifier.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = DeallocNotifier.m; sourceTree = "<group>"; };
 		3460488818F26F5400BC93B6 /* NSMethodSignature+Cedar.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = "NSMethodSignature+Cedar.h"; sourceTree = "<group>"; };
 		3460489318F2DBBF00BC93B6 /* CDRBlockHelper.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = CDRBlockHelper.h; sourceTree = "<group>"; };
 		34681C2B18FE451E009D38AC /* CDRTypeUtilities.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = CDRTypeUtilities.m; sourceTree = "<group>"; };
@@ -1623,6 +1628,8 @@
 				9D28051818E2321D00887CC4 /* ObjectWithValueEquality.m */,
 				AED10EBA18F46C0E00950904 /* FooSuperclass.h */,
 				AED10EBB18F46C0E00950904 /* FooSuperclass.m */,
+				343FAFE8190FDAEC0085AFEC /* DeallocNotifier.h */,
+				343FAFE9190FDAEC0085AFEC /* DeallocNotifier.m */,
 			);
 			path = Support;
 			sourceTree = "<group>";
@@ -2137,6 +2144,7 @@
 				1FE2ACBA18891FE90000C063 /* CedarDoubleARCSharedExamples.mm in Sources */,
 				968F9582161AC58200A78D36 /* CDRSymbolicatorSpec.mm in Sources */,
 				96A805E416D9B29C005F87FA /* CDRSpecFailureSpec.mm in Sources */,
+				34D93AD51911441300200C71 /* DeallocNotifier.m in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -2244,6 +2252,7 @@
 				AE9AA69715ADB99800617E1A /* CedarDoubleSharedExamples.mm in Sources */,
 				AE3E8F39184FEEE900633740 /* ObjectWithCollections.m in Sources */,
 				AE74903215B45EBA008EA127 /* CDRProtocolFakeSpec.mm in Sources */,
+				343FAFEA190FDAEC0085AFEC /* DeallocNotifier.m in Sources */,
 				96C95B7E161339160018606B /* CDRSymbolicatorSpec.mm in Sources */,
 				1F882AAC180FA8D800533238 /* BeSameInstanceAs_ARCSpec.mm in Sources */,
 				9672F0A91615C3F40012ED58 /* CDRSpecSpec.mm in Sources */,
@@ -2353,6 +2362,7 @@
 				44B9A71F1888661100CBCA1B /* ExampleWithPublicRunDates.m in Sources */,
 				AE18A80B13F4640600C8872C /* ContainSpec.mm in Sources */,
 				AED10EBD18F46C0E00950904 /* FooSuperclass.m in Sources */,
+				343FAFEB190FDAEC0085AFEC /* DeallocNotifier.m in Sources */,
 				AE6F3F351458D7C100C98F1E /* BeGreaterThanSpec.mm in Sources */,
 				34681C3118FE4B68009D38AC /* CDRTypeUtilitiesSpec.mm in Sources */,
 				AE53B68217E7BCE700D83D5E /* CedarNiceFakeSharedExamples.mm in Sources */,

--- a/Source/Doubles/CDRSpy.mm
+++ b/Source/Doubles/CDRSpy.mm
@@ -41,6 +41,15 @@
     return self;
 }
 
+- (BOOL)retainWeakReference {
+    __block id that = self;
+    __block BOOL res;
+    [self as_spied_class:^{
+        res = [that retainWeakReference];
+    }];
+    return res;
+}
+
 - (oneway void)release {
     __block id that = self;
     [self as_spied_class:^{

--- a/Source/Doubles/CDRSpyInfo.mm
+++ b/Source/Doubles/CDRSpyInfo.mm
@@ -1,10 +1,18 @@
 #import "CDRSpyInfo.h"
+#import "CDRSpy.h"
 #import "CedarDoubleImpl.h"
 #import <objc/runtime.h>
 
 static NSMutableSet *currentSpies__;
 
-@implementation CDRSpyInfo
+@interface CDRSpyInfo ()
+@property (nonatomic, assign) id originalObject;
+@property (nonatomic, weak) id weakOriginalObject;
+@end
+
+@implementation CDRSpyInfo {
+    __weak id _weakOriginalObject;
+}
 
 + (void)initialize {
     currentSpies__ = [[NSMutableSet alloc] init];
@@ -13,9 +21,11 @@ static NSMutableSet *currentSpies__;
 + (void)storeSpyInfoForObject:(id)object {
     CDRSpyInfo *spyInfo = [[[CDRSpyInfo alloc] init] autorelease];
     spyInfo.originalObject = object;
+    spyInfo.weakOriginalObject = object;
     spyInfo.publicClass = [object class];
     spyInfo.spiedClass = object_getClass(object);
     spyInfo.cedarDouble = [[[CedarDoubleImpl alloc] initWithDouble:object] autorelease];
+
     [currentSpies__ addObject:spyInfo];
 }
 
@@ -23,6 +33,7 @@ static NSMutableSet *currentSpies__;
     CDRSpyInfo *spyInfo = [CDRSpyInfo spyInfoForObject:object];
     if (spyInfo) {
         spyInfo.originalObject = nil;
+        spyInfo.weakOriginalObject = nil;
         [currentSpies__ removeObject:spyInfo];
         return YES;
     }
@@ -30,12 +41,10 @@ static NSMutableSet *currentSpies__;
 }
 
 - (void)dealloc {
-    if (self.originalObject) {
-        object_setClass(self.originalObject, self.spiedClass);
-    }
     self.publicClass = nil;
     self.spiedClass = nil;
     self.originalObject = nil;
+    self.weakOriginalObject = nil;
     self.cedarDouble = nil;
     [super dealloc];
 }
@@ -49,13 +58,12 @@ static NSMutableSet *currentSpies__;
 }
 
 + (CDRSpyInfo *)spyInfoForObject:(id)object {
-    return [currentSpies__ objectsPassingTest:^BOOL(CDRSpyInfo *spyInfo, BOOL *stop) {
+    for (CDRSpyInfo *spyInfo in currentSpies__) {
         if (spyInfo.originalObject == object) {
-            *stop = YES;
-            return YES;
+            return spyInfo;
         }
-        return NO;
-    }].anyObject;
+    }
+    return nil;
 }
 
 - (IMP)impForSelector:(SEL)selector {
@@ -82,7 +90,22 @@ static NSMutableSet *currentSpies__;
 }
 
 + (void)afterEach {
-    [currentSpies__ removeAllObjects];
+    for (CDRSpyInfo *spyInfo in [[currentSpies__ copy] autorelease]) {
+        id originalObject = spyInfo.weakOriginalObject;
+        if (originalObject) {
+            Cedar::Doubles::CDR_stop_spying_on(originalObject);
+        }
+    }
+}
+
+#pragma mark - Accessors
+
+- (id)weakOriginalObject {
+    return objc_loadWeak(&_weakOriginalObject);
+}
+
+- (void)setWeakOriginalObject:(id)originalObject {
+    objc_storeWeak(&_weakOriginalObject, originalObject);
 }
 
 @end

--- a/Source/Headers/Doubles/CDRSpyInfo.h
+++ b/Source/Headers/Doubles/CDRSpyInfo.h
@@ -6,7 +6,6 @@
 
 @property (nonatomic, assign) Class publicClass;
 @property (nonatomic, assign) Class spiedClass;
-@property (nonatomic, assign) id originalObject;
 @property (nonatomic, retain) CedarDoubleImpl *cedarDouble;
 
 + (void)storeSpyInfoForObject:(id)object;

--- a/Spec/Doubles/CDRSpySpec.mm
+++ b/Spec/Doubles/CDRSpySpec.mm
@@ -6,6 +6,7 @@
 #import "SimpleKeyValueObserver.h"
 #import "ArgumentReleaser.h"
 #import "ObjectWithValueEquality.h"
+#import "DeallocNotifier.h"
 #import <objc/runtime.h>
 
 extern "C" {
@@ -378,6 +379,17 @@ describe(@"spy_on", ^{
 
             itShouldPlayNiceWithKVO();
         });
+    });
+
+    it(@"should allow spied upon objects to deallocate normally", ^{
+        __block BOOL wasCalled = NO;
+        DeallocNotifier *notifier = [[DeallocNotifier alloc] initWithNotificationBlock:^{
+            wasCalled = YES;
+        }];
+        spy_on(notifier);
+        [notifier release];
+
+        wasCalled should be_truthy;
     });
 });
 

--- a/Spec/Support/DeallocNotifier.h
+++ b/Spec/Support/DeallocNotifier.h
@@ -1,0 +1,7 @@
+#import <Foundation/Foundation.h>
+
+@interface DeallocNotifier : NSObject
+
+- (instancetype)initWithNotificationBlock:(void (^)(void))block;
+
+@end

--- a/Spec/Support/DeallocNotifier.m
+++ b/Spec/Support/DeallocNotifier.m
@@ -1,0 +1,22 @@
+#import "DeallocNotifier.h"
+
+@interface DeallocNotifier ()
+@property (nonatomic, copy) void (^notificationBlock)(void);
+@end
+
+@implementation DeallocNotifier
+
+- (instancetype)initWithNotificationBlock:(void (^)(void))block {
+    if (self = [super init]) {
+        self.notificationBlock = block;
+    }
+    return self;
+}
+
+- (void)dealloc {
+    self.notificationBlock();
+    self.notificationBlock = nil;
+    [super dealloc];
+}
+
+@end


### PR DESCRIPTION
Fix issues with spies leaking
- Explicitly stop spying on objects after each example
- No longer relies on the timing of CDRSpyInfo instances being deallocated
- This fixes leaking caused by release messages being lost after the currentSpies__ set is cleared
- Spies now forward the private -retainWeakReference method to their real object which fixes overrelease bugs for objects which use a different reference counting implementation than NSProxy (e.g. some UIKit objects)

[#69580040]
