### PR TITLE
Print Cedar version number and git commit SHA when running specs

### DIFF
--- a/Cedar-Info.plist
+++ b/Cedar-Info.plist
@@ -13,7 +13,7 @@
 	<key>CFBundlePackageType</key>
 	<string>FMWK</string>
 	<key>CFBundleShortVersionString</key>
-	<string>1.0</string>
+	<string>0.9.6</string>
 	<key>CFBundleSignature</key>
 	<string>????</string>
 	<key>CFBundleVersion</key>

--- a/Cedar.xcodeproj/project.pbxproj
+++ b/Cedar.xcodeproj/project.pbxproj
@@ -14,6 +14,8 @@
 				AEEE225511DC2BD700029872 /* Build architecture-specific static libs */,
 				AEEE225A11DC2C0200029872 /* Build universal static lib */,
 				AEEE225E11DC2C5E00029872 /* Copy headers to framework */,
+				3444602A190CC3320076655A /* Copy Info.plist to framework */,
+				34446027190CAA930076655A /* Update version info */,
 			);
 			dependencies = (
 			);
@@ -1862,6 +1864,7 @@
 				AEEE1FB211DC271300029872 /* Resources */,
 				AEEE1FB311DC271300029872 /* Sources */,
 				AEEE1FB411DC271300029872 /* Frameworks */,
+				3468B7AA1909595200203B87 /* Update Version Info */,
 			);
 			buildRules = (
 			);
@@ -2025,6 +2028,48 @@
 /* End PBXResourcesBuildPhase section */
 
 /* Begin PBXShellScriptBuildPhase section */
+		34446027190CAA930076655A /* Update version info */ = {
+			isa = PBXShellScriptBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputPaths = (
+			);
+			name = "Update version info";
+			outputPaths = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /usr/bin/ruby;
+			shellScript = "key = \"CDRBuildVersionSHA\"\nver = `git rev-parse HEAD`.strip\nputs \"Git commit SHA is #{ver}\"\npath = \"#{ENV['BUILD_DIR']}/#{ENV['CONFIGURATION']}-iphoneuniversal/#{ENV['PRODUCT_NAME']}.framework/Resources/Info.plist\"\n`/usr/libexec/PlistBuddy -c \"Add :#{key} string #{ver}\" \"#{path}\"`";
+		};
+		3444602A190CC3320076655A /* Copy Info.plist to framework */ = {
+			isa = PBXShellScriptBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputPaths = (
+			);
+			name = "Copy Info.plist to framework";
+			outputPaths = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "cp \"${SRCROOT}/Cedar-Info.plist\" \"${BUILD_DIR}/${CONFIGURATION}-iphoneuniversal/${PRODUCT_NAME}.framework/Resources/Info.plist\"";
+		};
+		3468B7AA1909595200203B87 /* Update Version Info */ = {
+			isa = PBXShellScriptBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputPaths = (
+			);
+			name = "Update Version Info";
+			outputPaths = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /usr/bin/ruby;
+			shellScript = "key = \"CDRBuildVersionSHA\"\nver = `git rev-parse HEAD`.strip\nputs \"Git commit SHA is #{ver}\"\npath = \"#{ENV['BUILT_PRODUCTS_DIR']}/#{ENV['INFOPLIST_PATH']}\"\nputs \"Updating #{path}\"\n`/usr/libexec/PlistBuddy -c \"Add :#{key} string #{ver}\" \"#{path}\"`";
+		};
 		96158A84144A915E005895CE /* ShellScript */ = {
 			isa = PBXShellScriptBuildPhase;
 			buildActionMask = 2147483647;

--- a/Source/Headers/Reporters/CDRDefaultReporter.h
+++ b/Source/Headers/Reporters/CDRDefaultReporter.h
@@ -3,6 +3,8 @@
 @class CDRExample;
 
 @interface CDRDefaultReporter : NSObject <CDRExampleReporter> {
+    NSString *cedarVersionString_;
+
     NSArray *rootGroups_;
 
     NSMutableArray *pendingMessages_;
@@ -13,6 +15,9 @@
     NSDate *endTime_;
     unsigned int exampleCount_;
 }
+
+- (instancetype)initWithCedarVersion:(NSString *)cedarVersionString;
+
 @end
 
 @interface CDRDefaultReporter (Protected)

--- a/Source/Headers/Reporters/CDROTestReporter.h
+++ b/Source/Headers/Reporters/CDROTestReporter.h
@@ -1,4 +1,5 @@
 #import "CDRExampleReporter.h"
 
 @interface CDROTestReporter : NSObject <CDRExampleReporter>
+- (instancetype)initWithCedarVersion:(NSString *)cedarVersionString;
 @end

--- a/Source/Reporters/CDRDefaultReporter.m
+++ b/Source/Reporters/CDRDefaultReporter.m
@@ -16,8 +16,9 @@
 @implementation CDRDefaultReporter
 
 #pragma mark Memory
-- (id)init {
+- (instancetype)initWithCedarVersion:(NSString *)cedarVersionString {
     if (self = [super init]) {
+        cedarVersionString_ = [cedarVersionString retain];
         pendingMessages_ = [[NSMutableArray alloc] init];
         skippedMessages_ = [[NSMutableArray alloc] init];
         failureMessages_ = [[NSMutableArray alloc] init];
@@ -26,6 +27,7 @@
 }
 
 - (void)dealloc {
+    [cedarVersionString_ release];
     [rootGroups_ release];
     [startTime_ release];
     [endTime_ release];
@@ -40,6 +42,7 @@
     rootGroups_ = [groups retain];
     [self startObservingExamples:rootGroups_];
     startTime_ = [[NSDate alloc] init];
+    [self logText:[NSString stringWithFormat:@"Cedar Version: %@\n", cedarVersionString_]];
     [self logText:[NSString stringWithFormat:@"Running With Random Seed: %i\n\n", seed]];
 }
 

--- a/Source/Reporters/CDROTestReporter.m
+++ b/Source/Reporters/CDROTestReporter.m
@@ -7,6 +7,8 @@
 #import "CDROTestNamer.h"
 
 @interface CDROTestReporter ()
+@property (retain, nonatomic) NSString *cedarVersionString;
+
 @property (retain, nonatomic) NSDate *startTime;
 @property (retain, nonatomic) NSDate *endTime;
 @property (retain, nonatomic) NSDateFormatter *formatter;
@@ -22,6 +24,7 @@
 @implementation CDROTestReporter
 
 - (void)dealloc {
+    self.cedarVersionString = nil;
     self.startTime = nil;
     self.endTime = nil;
     self.formatter = nil;
@@ -32,12 +35,13 @@
     [super dealloc];
 }
 
-- (id)init {
+- (instancetype)initWithCedarVersion:(NSString *)cedarVersionString {
     self = [super init];
     if (self) {
         self.formatter = [[[NSDateFormatter alloc] init] autorelease];
         [self.formatter setDateFormat:@"YYYY-MM-dd HH:mm:ss Z"];
         self.namer = [[[CDROTestNamer alloc] init] autorelease];
+        self.cedarVersionString = cedarVersionString;
     }
     return self;
 }
@@ -48,6 +52,7 @@
     self.startTime = [NSDate date];
     self.rootGroups = groups;
 
+    [self logMessage:[NSString stringWithFormat:@"Cedar Version: %@", self.cedarVersionString]];
     [self logMessage:[NSString stringWithFormat:@"Cedar Random Seed: %d", seed]];
 
     [self startSuite:[self rootSuiteName] atDate:self.startTime];

--- a/Spec/Reporters/CDROTestReporterSpec.mm
+++ b/Spec/Reporters/CDROTestReporterSpec.mm
@@ -57,6 +57,7 @@ describe(@"CDROTestReporter", ^{
     __block CDRExample *passingExample, *failingExample, *focusedExample;
     __block NSString *bundleName;
     __block CDRReportDispatcher *dispatcher;
+    NSString *cedarVersionString = @"0.1.2 (a71e8f)";
 
     beforeEach(^{
         bundleName = [NSBundle mainBundle].bundleURL.pathComponents.lastObject;
@@ -68,7 +69,7 @@ describe(@"CDROTestReporter", ^{
             bundleName = @"Cedar.framework";
         }
 
-        reporter = [[[CDROTestReporter alloc] init] autorelease];
+        reporter = [[[CDROTestReporter alloc] initWithCedarVersion:cedarVersionString] autorelease];
         reporter.reporter_output = [NSMutableString string];
         dispatcher = [[[CDRReportDispatcher alloc] initWithReporters:@[reporter]] autorelease];
 
@@ -100,6 +101,10 @@ describe(@"CDROTestReporter", ^{
                 [dispatcher runWillStartWithGroups:@[group1] andRandomSeed:1337];
             });
 
+            it(@"should report the Cedar version", ^{
+                reporter.reporter_output should contain([NSString stringWithFormat:@"Cedar Version: %@", cedarVersionString]);
+            });
+
             it(@"should report the random seed", ^{
                 reporter.reporter_output should contain(@"Cedar Random Seed: 1337");
             });
@@ -125,6 +130,10 @@ describe(@"CDROTestReporter", ^{
 
             afterEach(^{
                 [SpecHelper specHelper].shouldOnlyRunFocused = originalState;
+            });
+
+            it(@"should report the Cedar version", ^{
+                reporter.reporter_output should contain([NSString stringWithFormat:@"Cedar Version: %@", cedarVersionString]);
             });
 
             it(@"should report the random seed", ^{


### PR DESCRIPTION
... if possible
- Works on Mac with dynamically-linked Cedar framework
- Works via CocoaPods, without git commit SHA
- iOS framework contains the version in its Info.plist, but can't print it when running

@idoru Is this what you had in mind?
[#54066481]
