### PR TITLE
Fix iOS 8-incompatible property on CDRSpecFailure

### DIFF
--- a/Source/Headers/CDRSpecFailure.h
+++ b/Source/Headers/CDRSpecFailure.h
@@ -8,7 +8,7 @@
 
 @property (nonatomic, retain, readonly) NSString *fileName;
 @property (nonatomic, assign, readonly) int lineNumber;
-@property (nonatomic, retain, readonly) NSArray *callStackReturnAddresses;
+@property (copy, readonly) NSArray *callStackReturnAddresses;
 
 + (id)specFailureWithReason:(NSString *)reason;
 + (id)specFailureWithReason:(NSString *)reason fileName:(NSString *)fileName lineNumber:(int)lineNumber;


### PR DESCRIPTION
We can probably remove this property altogether, as it's already defined in NSException.h (as a method on iOS 7 and as a property on iOS 8), but this fixes the problem for now.
