### PR TITLE
Make iOS suite template work on Xcode 6

### DIFF
--- a/CodeSnippetsAndTemplates/Templates/Project Templates/Cedar/OSX Cedar Example Spec.xctemplate/ExampleSpec.mm
+++ b/CodeSnippetsAndTemplates/Templates/Project Templates/Cedar/OSX Cedar Example Spec.xctemplate/ExampleSpec.mm
@@ -1,0 +1,39 @@
+#import <Cedar/Cedar.h>
+
+using namespace Cedar::Matchers;
+using namespace Cedar::Doubles;
+
+SPEC_BEGIN(ExampleSpec)
+
+/* This is not an exhaustive list of usages.
+   For more information, please visit https://github.com/pivotal/cedar */
+
+describe(@"Example specs on NSString", ^{
+
+    it(@"lowercaseString returns a new string with everything in lower case", ^{
+        [@"FOOBar" lowercaseString] should equal(@"foobar");
+    });
+
+    it(@"length returns the number of characters in the string", ^{
+        [@"internationalization" length] should equal(20);
+    });
+
+    describe(@"isEqualToString:", ^{
+        it(@"should return true if the strings are the same", ^{
+            [@"someString" isEqualToString:@"someString"] should be_truthy;
+        });
+
+        it(@"should return false if the strings are not the same", ^{
+            [@"someString" isEqualToString:@"anotherString"] should_not be_truthy;
+        });
+    });
+
+    describe(@"NSMutableString", ^{
+        it(@"should be a kind of NSString", ^{
+            [NSMutableString string] should be_instance_of([NSString class]).or_any_subclass();
+        });
+    });
+});
+
+SPEC_END
+

--- a/CodeSnippetsAndTemplates/Templates/Project Templates/Cedar/OSX Cedar Example Spec.xctemplate/TemplateInfo.plist
+++ b/CodeSnippetsAndTemplates/Templates/Project Templates/Cedar/OSX Cedar Example Spec.xctemplate/TemplateInfo.plist
@@ -3,11 +3,10 @@
 <plist version="1.0">
 <dict>
 	<key>Identifier</key>
-	<string>com.pivotallabs.cedar.exampleSpec</string>
+	<string>com.pivotallabs.cedar.macExampleSpec</string>
 	<key>InjectionTargets</key>
 	<array>
-		<string>com.pivotallabs.cedar.testingBundle</string>
-		<string>com.pivotallabs.cedar.iOSSpecSuite</string>
+		<string>com.pivotallabs.cedar.OSXTestingBundle</string>
 		<string>com.pivotallabs.cedar.OSXSpecSuite</string>
 	</array>
 	<key>Kind</key>

--- a/CodeSnippetsAndTemplates/Templates/Project Templates/Cedar/iOS Cedar Example Spec.xctemplate/ExampleSpec.mm
+++ b/CodeSnippetsAndTemplates/Templates/Project Templates/Cedar/iOS Cedar Example Spec.xctemplate/ExampleSpec.mm
@@ -1,3 +1,5 @@
+#import <Cedar-iOS/Cedar.h>
+
 using namespace Cedar::Matchers;
 using namespace Cedar::Doubles;
 

--- a/CodeSnippetsAndTemplates/Templates/Project Templates/Cedar/iOS Cedar Example Spec.xctemplate/TemplateInfo.plist
+++ b/CodeSnippetsAndTemplates/Templates/Project Templates/Cedar/iOS Cedar Example Spec.xctemplate/TemplateInfo.plist
@@ -1,0 +1,29 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>Identifier</key>
+	<string>com.pivotallabs.cedar.iosExampleSpec</string>
+	<key>InjectionTargets</key>
+  <array>
+		<string>com.pivotallabs.cedar.iOSSpecSuite</string>
+		<string>com.pivotallabs.cedar.iOSTestingBundle</string>
+	</array>
+	<key>Kind</key>
+	<string>Xcode.Xcode3.ProjectTemplateUnitKind</string>
+	<key>Nodes</key>
+	<array>
+		<string>ExampleSpec.mm</string>
+	</array>
+	<key>Definitions</key>
+	<dict>
+		<key>ExampleSpec.mm</key>
+		<dict>
+			<key>Path</key>
+			<string>ExampleSpec.mm</string>
+		</dict>
+	</dict>
+	<key>isCedarTemplate</key>
+	<true/>
+</dict>
+</plist>

--- a/CodeSnippetsAndTemplates/Templates/Project Templates/Cedar/iOS Cedar Spec Suite.xctemplate/TemplateInfo.plist
+++ b/CodeSnippetsAndTemplates/Templates/Project Templates/Cedar/iOS Cedar Spec Suite.xctemplate/TemplateInfo.plist
@@ -4,6 +4,8 @@
 <dict>
 	<key>Ancestors</key>
 	<array>
+		<string>com.apple.dt.unit.applicationBase</string>
+		<string>com.apple.dt.unit.iosBase</string>
 		<string>com.apple.dt.unit.objectiveCApplication</string>
 		<string>com.apple.dt.unit.iPhoneBase</string>
 		<string>com.apple.dt.unit.prefixable</string>


### PR DESCRIPTION
Apple has renamed the base iOS app templates in Xcode 6.  Since Xcode
helpfully ignores missing inherited templates, this change makes the
templates inherit from the old and new templates, which seems to work.

Also, prefix headers have been removed from Xcode 6 templates, so
ExampleSpec now imports Cedar itself so that it compiles (it probably
should have been doing this anyway).

Note that the prefix header files are still generated because targets
generated with Xcode 5 templates still depend on them, but they can be
safely deleted if created with Xcode 6.
