### PR TITLE
Ensure meta-class is restored for Class spies

### DIFF
--- a/Source/Doubles/CDRSpy.mm
+++ b/Source/Doubles/CDRSpy.mm
@@ -25,7 +25,7 @@
     if (!instance) {
         @throw [NSException exceptionWithName:NSInternalInconsistencyException reason:@"Cannot stop spying on nil" userInfo:nil];
     }
-    Class originalClass = [instance class];
+    Class originalClass = [CDRSpyInfo spyInfoForObject:instance].spiedClass;
     if ([CDRSpyInfo clearSpyInfoForObject:instance]) {
         object_setClass(instance, originalClass);
     }

--- a/Spec/Doubles/CDRSpySpec.mm
+++ b/Spec/Doubles/CDRSpySpec.mm
@@ -411,6 +411,24 @@ describe(@"spy_on", ^{
 
         wasCalled should be_truthy;
     });
+
+    describe(@"spying on a class", ^{
+        __block NSFileManager *fileManager;
+
+        beforeEach(^{
+            fileManager = nice_fake_for([NSFileManager class]);
+            spy_on([NSFileManager class]);
+            [NSFileManager class] stub_method(@selector(defaultManager)).and_return(fileManager);
+        });
+
+        it(@"should work for stubbing methods", ^{
+            [NSFileManager defaultManager] should be_same_instance_as(fileManager);
+        });
+
+        it(@"should reset state between tests", ^{
+            [(id<CedarDouble>)[NSFileManager defaultManager] sent_messages] should be_empty;
+        });
+    });
 });
 
 describe(@"stop_spying_on", ^{


### PR DESCRIPTION
[Fixes #78068472](AKA #248)

Not sure if we consider this enough test coverage for spying on classes, but thought I'd start with this PR first to see what folks think.
