### PR TITLE
Made upgradeCedarFramework work with paths containing spaces

### DIFF
--- a/upgradeCedarFramework
+++ b/upgradeCedarFramework
@@ -3,7 +3,7 @@
 echo "\n===== Upgrading framework =====\n"
 
 TARGET_PATH=$1
-if rake upgrade[$TARGET_PATH]
+if rake upgrade["$TARGET_PATH"]
 then
   echo "\n*** Finished upgrading the framework ***\n"
 else


### PR DESCRIPTION
The upgradeCedarFramework script didn't quote the target path, so it would fail if the path contained spaces.
