### PR TITLE
Attempt to run iOSFrameworkSpecs properly

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -381,7 +381,7 @@ namespace :frameworks do
   desc "Build Cedar and Cedar-iOS frameworks, and verify built Cedar-iOS.framework"
   task build: ['frameworks:ios:build', 'frameworks:osx:build'] do
     begin
-      Rake::Task['iosframeworkspecs:run'].execute
+      Rake::Task['suites:iosframeworkspecs:run'].invoke
     rescue Exception => e
       puts "Unable to run iOS static framework specs. Skipping validation of Cedar-iOS.framework (#{e})"
     end


### PR DESCRIPTION
- Runs the proper, suite: namespaced target
- Use #invoke to ensure suite is compiled before running

Related to delivered story: https://www.pivotaltracker.com/story/show/77215272
