### PR TITLE
Suggest a fix if an object fails the be_instance_of matcher but its class...

### DIFF
--- a/Source/Headers/Matchers/Base/BeInstanceOf.h
+++ b/Source/Headers/Matchers/Base/BeInstanceOf.h
@@ -24,6 +24,9 @@ namespace Cedar { namespace Matchers { namespace Private {
 
         BeInstanceOf & or_any_subclass();
 
+        template<typename U>
+        NSString * failure_message_for(const U &) const;
+
     protected:
         virtual NSString * failure_message_end() const;
 
@@ -40,6 +43,17 @@ namespace Cedar { namespace Matchers { namespace Private {
     inline BeInstanceOf & BeInstanceOf::or_any_subclass() {
         includeSubclasses_ = true;
         return *this;
+    }
+
+    template<typename U>
+    NSString * BeInstanceOf::failure_message_for(const U & value) const {
+        NSString *failureMessage = Base<BeInstanceOfMessageBuilder>::failure_message_for(value);
+
+        if ([NSStringFromClass(expectedClass_) isEqualToString:NSStringFromClass([value class])]) {
+            failureMessage = [failureMessage stringByAppendingFormat:@". %@", @"Did you accidentally add the class to your specs target also?"];
+        }
+
+        return failureMessage;
     }
 
     inline /*virtual*/ NSString * BeInstanceOf::failure_message_end() const {

--- a/Spec/Matchers/Base/BeInstanceOfSpec.mm
+++ b/Spec/Matchers/Base/BeInstanceOfSpec.mm
@@ -14,6 +14,18 @@ extern "C" {
 @interface FooDerived : FooBase; @end
 @implementation FooDerived; @end
 
+@interface BarNotMemberOfOwnClass : NSObject @end
+@implementation BarNotMemberOfOwnClass
+
+- (BOOL)isMemberOfClass:(Class)aClass {
+    return NO;
+}
+- (BOOL)isKindOfClass:(Class)aClass {
+    return NO;
+}
+
+@end
+
 using namespace Cedar::Matchers;
 
 SPEC_BEGIN(BeInstanceOfSpec)
@@ -75,6 +87,25 @@ describe(@"be_instance_of matcher", ^{
                 });
             });
         });
+
+        describe(@"when the actual value is not an instance of the expected class but they have the same class name", ^{
+            Class expectedClass = [BarNotMemberOfOwnClass class];
+            id actualValue = [[[BarNotMemberOfOwnClass alloc] init] autorelease];
+
+            describe(@"positive match", ^{
+                it(@"should fail with a failure message suggesting solution to the problem", ^{
+                    expectFailureWithMessage([NSString stringWithFormat:@"Expected <%@ (%@)> to be an instance of class <%@>. Did you accidentally add the class to your specs target also?", actualValue, [actualValue class], expectedClass], ^{
+                        expect(actualValue).to(be_instance_of(expectedClass));
+                    });
+                });
+            });
+
+            describe(@"negative match", ^{
+                it(@"should should pass", ^{
+                    expect(actualValue).to_not(be_instance_of(expectedClass));
+                });
+            });
+        });
     });
 
     describe(@"with the or_any_subclass decoration", ^{
@@ -122,6 +153,25 @@ describe(@"be_instance_of matcher", ^{
             describe(@"positive match", ^{
                 it(@"should fail with a sensible failure message", ^{
                     expectFailureWithMessage([NSString stringWithFormat:@"Expected <%@ (%@)> to be an instance of class <%@>, or any of its subclasses", actualValue, [actualValue class], expectedClass], ^{
+                        expect(actualValue).to(be_instance_of(expectedClass).or_any_subclass());
+                    });
+                });
+            });
+
+            describe(@"negative match", ^{
+                it(@"should should pass", ^{
+                    expect(actualValue).to_not(be_instance_of(expectedClass).or_any_subclass());
+                });
+            });
+        });
+
+        describe(@"when the actual value is not an instance of the expected class but they have the same class name", ^{
+            Class expectedClass = [BarNotMemberOfOwnClass class];
+            id actualValue = [[[BarNotMemberOfOwnClass alloc] init] autorelease];
+
+            describe(@"positive match", ^{
+                it(@"should fail with a failure message suggesting solution to the problem", ^{
+                    expectFailureWithMessage([NSString stringWithFormat:@"Expected <%@ (%@)> to be an instance of class <%@>, or any of its subclasses. Did you accidentally add the class to your specs target also?", actualValue, [actualValue class], expectedClass], ^{
                         expect(actualValue).to(be_instance_of(expectedClass).or_any_subclass());
                     });
                 });


### PR DESCRIPTION
...has the same name as the expected class

People commonly make the mistake of adding production classes to the spec target as well as the app target, which leads to confusing failures like: 

`Expected <<Foo: 0x7fa522ccf350> (Foo)> to be an instance of class <Foo>.`

This change tries to guide the developer to the most common solution for this issue. Perhaps we should consider adding a slightly more detailed guide to the wiki/FAQ with a couple Xcode screenshots pointing to the relevant Target Membership checkboxes and include a link to that in this suggestion string?

Hat tip to @xtreme-james-cooper and @pivotal-fahad-muntaz, the latest in a string of people who I have seen baffled by this issue recently.
