### PR TITLE
Allows developers to re-stub stubbed methods by adding a call to again()

### DIFF
--- a/Source/Doubles/InvocationMatcher.mm
+++ b/Source/Doubles/InvocationMatcher.mm
@@ -4,8 +4,7 @@
 
 namespace Cedar { namespace Doubles {
 
-    InvocationMatcher::InvocationMatcher(const SEL selector) :
-    expectedSelector_(selector) {
+    InvocationMatcher::InvocationMatcher(const SEL selector) : expectedSelector_(selector) {
     }
 
     void InvocationMatcher::add_argument(const Argument::shared_ptr_t argument) {

--- a/Source/Doubles/StubbedMethod.mm
+++ b/Source/Doubles/StubbedMethod.mm
@@ -8,14 +8,15 @@
 
 namespace Cedar { namespace Doubles {
 
-    StubbedMethod::StubbedMethod(SEL selector) : InvocationMatcher(selector), exception_to_raise_(0), invocation_block_(0), implementation_block_(0) {}
-    StubbedMethod::StubbedMethod(const char * method_name) : InvocationMatcher(sel_registerName(method_name)), exception_to_raise_(0), invocation_block_(0), implementation_block_(0) {}
+    StubbedMethod::StubbedMethod(SEL selector) : InvocationMatcher(selector), exception_to_raise_(0), invocation_block_(0), implementation_block_(0), is_override_(false) {}
+    StubbedMethod::StubbedMethod(const char * method_name) : InvocationMatcher(sel_registerName(method_name)), exception_to_raise_(0), invocation_block_(0), implementation_block_(0), is_override_(false) {}
     StubbedMethod::StubbedMethod(const StubbedMethod &rhs)
     : InvocationMatcher(rhs)
     , return_value_(rhs.return_value_)
     , invocation_block_([rhs.invocation_block_ retain])
     , implementation_block_([rhs.implementation_block_ retain])
-    , exception_to_raise_(rhs.exception_to_raise_) {}
+    , exception_to_raise_(rhs.exception_to_raise_)
+    , is_override_(rhs.is_override_) {}
 
     /*virtual*/ StubbedMethod::~StubbedMethod() {
         [invocation_block_ release];
@@ -57,6 +58,11 @@ namespace Cedar { namespace Doubles {
 
     StubbedMethod & StubbedMethod::and_with(const Argument::shared_ptr_t argument) {
         return with(argument);
+    }
+
+    StubbedMethod & StubbedMethod::again() {
+        this->is_override_ = true;
+        return *this;
     }
 
     StubbedMethod & StubbedMethod::and_raise_exception() {

--- a/Source/Headers/Doubles/StubbedMethod.h
+++ b/Source/Headers/Doubles/StubbedMethod.h
@@ -28,6 +28,7 @@ namespace Cedar { namespace Doubles {
 
         StubbedMethod & with(const Argument::shared_ptr_t argument);
         StubbedMethod & and_with(const Argument::shared_ptr_t argument);
+        StubbedMethod & again();
 
         template<typename T, typename... ArgumentPack>
         StubbedMethod & with(const T &, ArgumentPack... pack);
@@ -42,6 +43,7 @@ namespace Cedar { namespace Doubles {
         StubbedMethod & and_raise_exception(NSObject * exception);
 
         ReturnValue & return_value() const { return *return_value_; };
+        bool is_override() const { return is_override_; };
 
         struct SelCompare {
             bool operator() (const SEL& lhs, const SEL& rhs) const {
@@ -74,6 +76,7 @@ namespace Cedar { namespace Doubles {
         void raise_for_multiple_blocks() const;
     private:
         ReturnValue::shared_ptr_t return_value_;
+        bool is_override_;
         invocation_block_t invocation_block_;
         implementation_block_t implementation_block_;
         NSObject * exception_to_raise_;


### PR DESCRIPTION
Addresses https://github.com/pivotal/cedar/issues/284

Attempts were made at following existing coding conventions but feedback is welcome.
