### PR TITLE
Fix bug where cedar didn't run focused tests in bundles.

### DIFF
--- a/Source/CDRFunctions.m
+++ b/Source/CDRFunctions.m
@@ -434,7 +434,8 @@ NSString *CDRGetTestBundleExtension() {
     NSString *extension = nil;;
 
     NSArray *arguments = [[NSProcessInfo processInfo] arguments];
-    if ([arguments containsObject:@"-XCTest"]) {
+    NSSet *xctestFlags = [NSSet setWithArray:@[@"-XCTest", @"-XCTestScopeFile"]];
+    if ([xctestFlags intersectsSet:[NSSet setWithArray:arguments]]) {
         extension = @".xctest";
     } else if ([arguments containsObject:@"-SenTest"]) {
         extension = @".octest";


### PR DESCRIPTION
A better method might be needed (note: test bundles don't always use xctest binary).

[#82513346]
