### PR TITLE
Fix implicit conversion warning on 64bit targets

### DIFF
--- a/Source/Extensions/NSInvocation+Cedar.m
+++ b/Source/Extensions/NSInvocation+Cedar.m
@@ -79,7 +79,7 @@ static char COPIED_BLOCKS_KEY;
         NSUInteger size;
         NSGetSizeAndAlignment([methodSignature getArgumentTypeAtIndex:argIndex], &size, NULL);
         char argBuffer[size];
-        memset(argBuffer, sizeof(argBuffer), sizeof(char));
+        memset(argBuffer, (int)sizeof(argBuffer), sizeof(char));
         [self getArgument:argBuffer atIndex:argIndex];
 
         const char *argType = [methodSignature getArgumentTypeAtIndex:argIndex];


### PR DESCRIPTION
We've been seeing these warnings on our project and thought it was about time someone silenced them :)
