### PR TITLE
Allow stubbing & expectation for pointer arguments

### DIFF
--- a/Source/Headers/Doubles/Arguments/ValueArgument.h
+++ b/Source/Headers/Doubles/Arguments/ValueArgument.h
@@ -4,6 +4,16 @@
 
 namespace Cedar { namespace Doubles {
 
+    inline const char *strip_encoding_qualifiers(const char *);
+
+    const char *strip_encoding_qualifiers(const char *encoding) {
+        const char *newStart = encoding;
+        while (strchr("rnNoORV", newStart[0])) {
+            ++newStart;
+        }
+        return newStart;
+    }
+
     template<typename T>
     class ValueArgument : public Argument {
     private:
@@ -23,6 +33,7 @@ namespace Cedar { namespace Doubles {
         virtual unsigned int specificity_ranking() const;
 
     protected:
+        bool matches_encoding_excluding_qualifiers(const char *) const;
         bool both_are_objects(const char *) const;
         bool both_are_not_objects(const char *) const;
         bool both_are_not_pointers(const char *) const;
@@ -58,7 +69,8 @@ namespace Cedar { namespace Doubles {
 
     template<typename T>
     /* virtual */ bool ValueArgument<T>::matches_encoding(const char * actual_argument_encoding) const {
-        return this->both_are_objects(actual_argument_encoding) ||
+        return this->matches_encoding_excluding_qualifiers(actual_argument_encoding) ||
+        this->both_are_objects(actual_argument_encoding) ||
         this->both_are_not_objects_pointers_nor_cstrings(actual_argument_encoding) ||
         this->nil_argument(actual_argument_encoding);
     }
@@ -77,6 +89,16 @@ namespace Cedar { namespace Doubles {
     /* virtual */ unsigned int ValueArgument<T>::specificity_ranking() const { return 1000; }
 
 #pragma mark - Protected interface
+    template<typename T>
+    bool ValueArgument<T>::matches_encoding_excluding_qualifiers(const char * actual_argument_encoding) const {
+        const char *encoding_excluding_qualifiers = strip_encoding_qualifiers(@encode(T));
+        const char *actual_argument_encoding_excluding_qualifiers = strip_encoding_qualifiers(actual_argument_encoding);
+        if (strlen(encoding_excluding_qualifiers) == strlen(actual_argument_encoding_excluding_qualifiers)) {
+            return 0 == strcmp(encoding_excluding_qualifiers, actual_argument_encoding_excluding_qualifiers);
+        }
+        return false;
+    }
+
     template<typename T>
     bool ValueArgument<T>::both_are_objects(const char * actual_argument_encoding) const {
         return 0 == strncmp(@encode(T), "@", 1) && 0 == strncmp(actual_argument_encoding, "@", 1);

--- a/Spec/Doubles/CedarDoubleSharedExamples.mm
+++ b/Spec/Doubles/CedarDoubleSharedExamples.mm
@@ -863,6 +863,57 @@ sharedExamplesFor(@"a Cedar double", ^(NSDictionary *sharedContext) {
                     });
                 });
 
+                context(@"with a non-object non-char pointer, when invoked with the argument", ^{
+                    __block BOOL stubbedBehaviorWasInvoked;
+                    __block int *pointerToPrimitivePointer;
+
+                    beforeEach(^{
+                        int primitive = 42;
+                        stubbedBehaviorWasInvoked = NO;
+                        myDouble stub_method(@selector(methodWithPrimitivePointerArgument:)).with(&primitive).and_do(^(NSInvocation *) {
+                            stubbedBehaviorWasInvoked = YES;
+                        });
+
+                        [myDouble methodWithPrimitivePointerArgument:&primitive];
+                        pointerToPrimitivePointer = &primitive;
+                    });
+
+                    it(@"should record the invocation", ^{
+                        myDouble should have_received("methodWithPrimitivePointerArgument:").with(pointerToPrimitivePointer);
+                    });
+
+                    it(@"should invoke the stubbed behavior", ^{
+                        stubbedBehaviorWasInvoked should be_truthy;
+                    });
+                });
+
+                context(@"with an object pointer, when invoked with the argument", ^{
+                    __block BOOL stubbedBehaviorWasInvoked;
+                    __block id *pointerToObjectPointer;
+
+                    beforeEach(^{
+                        NSError *error = [NSError errorWithDomain:@"ImTheTester" code:12345 userInfo:nil];
+
+                        stubbedBehaviorWasInvoked = NO;
+                        myDouble stub_method(@selector(methodWithObjectPointerArgument:)).with(&error).and_do(^(NSInvocation *) {
+                            stubbedBehaviorWasInvoked = YES;
+                        });
+
+                        [myDouble methodWithObjectPointerArgument:&error];
+
+                        myDouble should have_received("methodWithObjectPointerArgument:").with(&error);
+                        pointerToObjectPointer = &error;
+                    });
+
+                    it(@"should record the invocation", ^{
+                        myDouble should have_received("methodWithObjectPointerArgument:").with(pointerToObjectPointer);
+                    });
+
+                    it(@"should invoke the stubbed behavior", ^{
+                        stubbedBehaviorWasInvoked should be_truthy;
+                    });
+                });
+
                 context(@"with an argument specified as anything", ^{
                     NSNumber *arg1 = @3;
                     NSNumber *arg2 = @123;

--- a/Spec/Support/SimpleIncrementer.h
+++ b/Spec/Support/SimpleIncrementer.h
@@ -32,6 +32,8 @@ typedef LargeIncrementerStruct (^ComplexIncrementerBlock)(NSNumber *, LargeIncre
 - (LargeIncrementerStruct)methodWithLargeStruct1:(LargeIncrementerStruct)struct1 andLargeStruct2:(LargeIncrementerStruct)struct2;
 - (void)methodWithNumber:(NSNumber *)number complexBlock:(ComplexIncrementerBlock)block;
 - (NSString *)methodWithFooSuperclass:(FooSuperclass *)fooInstance;
+- (void)methodWithPrimitivePointerArgument:(int *)arg;
+- (void)methodWithObjectPointerArgument:(out id *)anObjectPointer;
 
 @optional
 - (size_t)whatIfIIncrementedBy:(size_t)amount;

--- a/Spec/Support/SimpleIncrementer.m
+++ b/Spec/Support/SimpleIncrementer.m
@@ -77,4 +77,10 @@
     return @"";
 }
 
+- (void)methodWithPrimitivePointerArgument:(int *)arg {
+}
+
+- (void)methodWithObjectPointerArgument:(out id *)anObjectPointer {
+}
+
 @end


### PR DESCRIPTION
Took a stab at this today. Credit to @joemasilotti for finding and reporting this bug.

Please check as I did this while soloing.

Also, I'm not sure of the potential consequences of ignoring type qualifier information, but it looks like this typically isn't present for the runtime, just for encodings from the NSMethodSignature.