### PR TITLE
Allow stubbing & expectation for pointer arguments

### DIFF
--- a/Spec/Doubles/CedarDoubleSharedExamples.mm
+++ b/Spec/Doubles/CedarDoubleSharedExamples.mm
@@ -863,6 +863,57 @@ sharedExamplesFor(@"a Cedar double", ^(NSDictionary *sharedContext) {
                     });
                 });
 
+                context(@"with a non-object non-char pointer, when invoked with the argument", ^{
+                    __block BOOL stubbedBehaviorWasInvoked;
+                    __block int *pointerToPrimitivePointer;
+
+                    beforeEach(^{
+                        int primitive = 42;
+                        stubbedBehaviorWasInvoked = NO;
+                        myDouble stub_method(@selector(methodWithPrimitivePointerArgument:)).with(&primitive).and_do(^(NSInvocation *) {
+                            stubbedBehaviorWasInvoked = YES;
+                        });
+
+                        [myDouble methodWithPrimitivePointerArgument:&primitive];
+                        pointerToPrimitivePointer = &primitive;
+                    });
+
+                    it(@"should record the invocation", ^{
+                        myDouble should have_received("methodWithPrimitivePointerArgument:").with(pointerToPrimitivePointer);
+                    });
+
+                    it(@"should invoke the stubbed behavior", ^{
+                        stubbedBehaviorWasInvoked should be_truthy;
+                    });
+                });
+
+                context(@"with an object pointer, when invoked with the argument", ^{
+                    __block BOOL stubbedBehaviorWasInvoked;
+                    __block id *pointerToObjectPointer;
+
+                    beforeEach(^{
+                        NSError *error = [NSError errorWithDomain:@"ImTheTester" code:12345 userInfo:nil];
+
+                        stubbedBehaviorWasInvoked = NO;
+                        myDouble stub_method(@selector(methodWithObjectPointerArgument:)).with(&error).and_do(^(NSInvocation *) {
+                            stubbedBehaviorWasInvoked = YES;
+                        });
+
+                        [myDouble methodWithObjectPointerArgument:&error];
+
+                        myDouble should have_received("methodWithObjectPointerArgument:").with(&error);
+                        pointerToObjectPointer = &error;
+                    });
+
+                    it(@"should record the invocation", ^{
+                        myDouble should have_received("methodWithObjectPointerArgument:").with(pointerToObjectPointer);
+                    });
+
+                    it(@"should invoke the stubbed behavior", ^{
+                        stubbedBehaviorWasInvoked should be_truthy;
+                    });
+                });
+
                 context(@"with an argument specified as anything", ^{
                     NSNumber *arg1 = @3;
                     NSNumber *arg2 = @123;

--- a/Spec/Support/SimpleIncrementer.h
+++ b/Spec/Support/SimpleIncrementer.h
@@ -32,6 +32,8 @@ typedef LargeIncrementerStruct (^ComplexIncrementerBlock)(NSNumber *, LargeIncre
 - (LargeIncrementerStruct)methodWithLargeStruct1:(LargeIncrementerStruct)struct1 andLargeStruct2:(LargeIncrementerStruct)struct2;
 - (void)methodWithNumber:(NSNumber *)number complexBlock:(ComplexIncrementerBlock)block;
 - (NSString *)methodWithFooSuperclass:(FooSuperclass *)fooInstance;
+- (void)methodWithPrimitivePointerArgument:(int *)arg;
+- (void)methodWithObjectPointerArgument:(out id *)anObjectPointer;
 
 @optional
 - (size_t)whatIfIIncrementedBy:(size_t)amount;

--- a/Spec/Support/SimpleIncrementer.m
+++ b/Spec/Support/SimpleIncrementer.m
@@ -77,4 +77,10 @@
     return @"";
 }
 
+- (void)methodWithPrimitivePointerArgument:(int *)arg {
+}
+
+- (void)methodWithObjectPointerArgument:(out id *)anObjectPointer {
+}
+
 @end


### PR DESCRIPTION
Slightly amended version of #312 which removes an unnecessary call to both_are_objects.

Credit to @joemasilotti for finding and reporting this bug.
