### PR TITLE
Print a helpful message if a matcher fails while setting up specs.

### DIFF
--- a/Source/CDRSpec.m
+++ b/Source/CDRSpec.m
@@ -28,7 +28,15 @@ CDRExampleGroup * describe(NSString *text, CDRSpecBlock block) {
         group = [CDRExampleGroup groupWithText:text];
         [parentGroup add:group];
         CDR_currentSpec.currentGroup = group;
-        block();
+
+        @try {
+            block();
+        }
+        @catch (CDRSpecFailure *failure) {
+            NSString *reason = [NSString stringWithFormat:@"Caught a spec failure before the specs began to run. Did you forget to put your assertion into an `it` block?. The failure was:\n%@", failure];
+            [[NSException exceptionWithName:NSInternalInconsistencyException reason:reason userInfo:nil] raise];
+        }
+
         if ([group.examples count] == 0) {
             block = placeholderPendingTestBlock;
             block();

--- a/Spec/SpecSpec.mm
+++ b/Spec/SpecSpec.mm
@@ -167,6 +167,24 @@ describe(@"Matchers", ^{
             });
         });
     });
+
+    describe(@"that fail outside of an `it` block", ^{
+        __block NSException *caughtException = nil;
+
+        @try {
+            describe(@"performing the assertion", ^{
+                1 should equal(2);
+            });
+        }
+        @catch (NSException *exception) {
+            caughtException = [exception retain];
+        }
+
+        it(@"should raise an exception with a helpful message", ^{
+            caughtException.name should equal(NSInternalInconsistencyException);
+            caughtException.reason should contain(@"Caught a spec failure before the specs began to run. Did you forget to put your assertion into an `it` block?. The failure was:");
+        });
+    });
 });
 
 describe(@"a describe block", ^{


### PR DESCRIPTION
This can occur by accidentally forgetting to create an `it` block before writing the assertion.

I've seen people encounter this a few times and get very confused. Because any `beforeEach` blocks won't have run to set up context, even a simple assertion is likely to fail.