### PR TITLE
Update templates to work with Xcode 6.3

### DIFF
--- a/CodeSnippetsAndTemplates/Templates/File Templates/Cedar/Cedar Spec.xctemplate/TemplateInfo.plist
+++ b/CodeSnippetsAndTemplates/Templates/File Templates/Cedar/Cedar Spec.xctemplate/TemplateInfo.plist
@@ -17,19 +17,29 @@
 	<key>Options</key>
 	<array>
 		<dict>
-			<key>Description</key>
-			<string>The name of the class to spec</string>
-			<key>Identifier</key>
-			<string>productName</string>
-			<key>Name</key>
-			<string>Class to Spec</string>
-			<key>NotPersisted</key>
-			<true/>
-			<key>Required</key>
-			<true/>
-			<key>Type</key>
-			<string>text</string>
-		</dict>
+    	<key>Default</key>
+    	<string/>
+    	<key>Description</key>
+    	<string>The name of the class to spec</string>
+    	<key>Identifier</key>
+    	<string>cedarClass</string>
+    	<key>Name</key>
+    	<string>Class to Spec</string>
+    	<key>Required</key>
+    	<true/>
+    	<key>NotPersisted</key>
+    	<true/>
+    	<key>Type</key>
+    	<string>text</string>
+    </dict>
+    <dict>
+      	<key>Default</key>
+      	<string>___VARIABLE_cedarClass:identifier___</string>
+      	<key>Identifier</key>
+      	<string>productName</string>
+      	<key>Type</key>
+      	<string>static</string>
+    </dict>
 	</array>
 	<key>Platforms</key>
 	<array>

--- a/CodeSnippetsAndTemplates/Templates/File Templates/Cedar/Cedar Spec.xctemplate/___FILEBASENAME___Spec.mm
+++ b/CodeSnippetsAndTemplates/Templates/File Templates/Cedar/Cedar Spec.xctemplate/___FILEBASENAME___Spec.mm
@@ -1,13 +1,13 @@
 #import <Cedar/Cedar.h>
-#import "___FILEBASENAME___.h"
+#import "___VARIABLE_cedarClass:identifier___.h"
 
 using namespace Cedar::Matchers;
 using namespace Cedar::Doubles;
 
-SPEC_BEGIN(___FILEBASENAMEASIDENTIFIER___Spec)
+SPEC_BEGIN(___VARIABLE_cedarClass:identifier___Spec)
 
-describe(@"___FILEBASENAMEASIDENTIFIER___", ^{
-    __block ___FILEBASENAMEASIDENTIFIER___ *<#object under test#>;
+describe(@"___VARIABLE_cedarClass:identifier___", ^{
+    __block ___VARIABLE_cedarClass:identifier___ *<#object under test#>;
 
     beforeEach(^{
 


### PR DESCRIPTION
Untested with earlier versions of xcode.

Apparently in Xcode 6.3 the TemplateInfo.plist has a version of the macros that
xcode provides (e.g.:: `___FILENAMEBASE___`) that are different from the contents of
the template. The template contents use the *actual* file name, rather than what the
user provides.

This fix just captures the class the user typed as a variable, and then uses it
in the template. I believe this should work on earlier versions of Xcode, but
I haven't had the liberty to check yet.

Fixes #324