### PR TITLE
be_same_instance_as matcher should not match nil values

### DIFF
--- a/Source/Headers/Matchers/Base/BeSameInstanceAs.h
+++ b/Source/Headers/Matchers/Base/BeSameInstanceAs.h
@@ -79,6 +79,11 @@ namespace Cedar { namespace Matchers { namespace Private {
 
     template<typename T> template<typename U>
     bool BeSameInstanceAs<T>::matches(U * const & actualValue) const {
+        if (actualValue == nil && expectedValue_ == nil) {
+            [[CDRSpecFailure specFailureWithReason:@"Unexpected use of be_same_instance_as matcher to check for nil. Both the actual and given values are nil. This is probably not what you intended to verify."] raise];
+            return NO;
+        }
+
 #pragma clang diagnostic push
 #pragma clang diagnostic ignored "-Wcompare-distinct-pointer-types"
         return actualValue == expectedValue_;

--- a/Spec/Matchers/Base/BeSameInstanceAsSpec.mm
+++ b/Spec/Matchers/Base/BeSameInstanceAsSpec.mm
@@ -64,6 +64,20 @@ describe(@"be_same_instance_as matcher", ^{
             });
         });
     });
+
+    describe(@"when the actual value is nil", ^{
+        int *actualValue = nil;
+
+        describe(@"and the values are both nil", ^{
+            int *expectedValue = nil;
+
+            it(@"should not pass", ^{
+                expectFailureWithMessage(@"Unexpected use of be_same_instance_as matcher to check for nil. Both the actual and given values are nil. This is probably not what you intended to verify.", ^{
+                    expect(actualValue).to(be_same_instance_as(expectedValue));
+                });
+            });
+        });
+    });
 });
 
 SPEC_END


### PR DESCRIPTION
@wileykestner discovered this on our project this morning. Our understanding of the `be_same_instance_as` matcher is that it helps users verify that their objects are actually the correct instance of their objects they created under test. We had a scenario where we  had failed to actually setup our test objects, and our tests passed before we had wrote a single line of code.

```objc
describe("a passing test", ^{
  __block MyDependency *dependency;
  __block MyClass *subject;

  beforeEach(^{
    subject = [[MyClass alloc] initWithDependency:dependency];
  });

  it(@"should not be passing yet, but it does", ^{
    subject.dependency should be_same_instance_as(dependency);
  });
});
```

Unfortunately, this is a non-backwards compatible change, since it changes the contract of `be_same_instance_as`. 