### PR TITLE
Xcode7 compilation updates

### DIFF
--- a/Cedar.xcodeproj/xcshareddata/xcschemes/Cedar OS X Host App.xcscheme
+++ b/Cedar.xcodeproj/xcshareddata/xcschemes/Cedar OS X Host App.xcscheme
@@ -62,6 +62,8 @@
             ReferencedContainer = "container:Cedar.xcodeproj">
          </BuildableReference>
       </MacroExpansion>
+      <AdditionalOptions>
+      </AdditionalOptions>
    </TestAction>
    <LaunchAction
       selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
@@ -71,8 +73,10 @@
       buildConfiguration = "Debug"
       ignoresPersistentStateOnLaunch = "NO"
       debugDocumentVersioning = "YES"
+      debugServiceExtension = "internal"
       allowLocationSimulation = "YES">
-      <BuildableProductRunnable>
+      <BuildableProductRunnable
+         runnableDebuggingMode = "0">
          <BuildableReference
             BuildableIdentifier = "primary"
             BlueprintIdentifier = "AE248F9719DCD52500092C14"
@@ -90,7 +94,8 @@
       useCustomWorkingDirectory = "NO"
       buildConfiguration = "Release"
       debugDocumentVersioning = "YES">
-      <BuildableProductRunnable>
+      <BuildableProductRunnable
+         runnableDebuggingMode = "0">
          <BuildableReference
             BuildableIdentifier = "primary"
             BlueprintIdentifier = "AE248F9719DCD52500092C14"

--- a/Cedar.xcodeproj/xcshareddata/xcschemes/Cedar iOS XCTest Tests.xcscheme
+++ b/Cedar.xcodeproj/xcshareddata/xcschemes/Cedar iOS XCTest Tests.xcscheme
@@ -48,6 +48,8 @@
             ReferencedContainer = "container:Cedar.xcodeproj">
          </BuildableReference>
       </MacroExpansion>
+      <AdditionalOptions>
+      </AdditionalOptions>
    </TestAction>
    <LaunchAction
       selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
@@ -57,8 +59,10 @@
       buildConfiguration = "Debug"
       ignoresPersistentStateOnLaunch = "NO"
       debugDocumentVersioning = "YES"
+      debugServiceExtension = "internal"
       allowLocationSimulation = "YES">
-      <BuildableProductRunnable>
+      <BuildableProductRunnable
+         runnableDebuggingMode = "0">
          <BuildableReference
             BuildableIdentifier = "primary"
             BlueprintIdentifier = "96B5F9F5144A81A7000A6A5D"
@@ -76,7 +80,8 @@
       useCustomWorkingDirectory = "NO"
       buildConfiguration = "Release"
       debugDocumentVersioning = "YES">
-      <BuildableProductRunnable>
+      <BuildableProductRunnable
+         runnableDebuggingMode = "0">
          <BuildableReference
             BuildableIdentifier = "primary"
             BlueprintIdentifier = "96B5F9F5144A81A7000A6A5D"

--- a/Spec/CDRSpecFailureSpec.mm
+++ b/Spec/CDRSpecFailureSpec.mm
@@ -93,7 +93,7 @@ describe(@"CDRSpecFailure", ^{
             context(@"when file name and line number are specified in exception's userInfo", ^{
                 beforeEach(^{
                     NSDictionary *userInfo = [NSDictionary dictionaryWithObjectsAndKeys:@"File.m", @"fileName", [NSNumber numberWithInt:123], @"lineNumber", nil];
-                    NSException *exception = [NSException exceptionWithName:nil reason:@"exception reason" userInfo:userInfo];
+                    NSException *exception = [NSException exceptionWithName:@"boo" reason:@"exception reason" userInfo:userInfo];
                     failure = [CDRSpecFailure specFailureWithRaisedObject:exception];
                 });
 
@@ -112,7 +112,7 @@ describe(@"CDRSpecFailure", ^{
 
             context(@"when file name and line number are not specified in userInfo of exception", ^{
                 beforeEach(^{
-                    NSException *exception = [NSException exceptionWithName:nil reason:@"exception reason" userInfo:nil];
+                    NSException *exception = [NSException exceptionWithName:@"boo" reason:@"exception reason" userInfo:nil];
                     failure = [CDRSpecFailure specFailureWithRaisedObject:exception];
                 });
 

--- a/Spec/Doubles/CedarDoubleARCSharedExamples.mm
+++ b/Spec/Doubles/CedarDoubleARCSharedExamples.mm
@@ -43,7 +43,6 @@ sharedExamplesFor(@"a Cedar double when used with ARC", ^(NSDictionary *sharedCo
                 });
 
                 while (!called) {
-                    [[NSRunLoop currentRunLoop] addTimer:[NSTimer timerWithTimeInterval:0.1 invocation:nil repeats:NO] forMode:NSDefaultRunLoopMode];
                     NSDate *futureDate = [NSDate dateWithTimeIntervalSinceNow:0.1];
                     [[NSRunLoop currentRunLoop] runUntilDate:futureDate];
                 }


### PR DESCRIPTION
Here are a few updates for Xcode 7 - the compilation fixes expose failing tests in the symbolicator, which we probably need to look into.

This is harmless to merge for Xcode 6.3, but full Xcode 7 compatibility requires a bit more work, or at least investigation.

See also #333 , which will require some refactoring.