### PR TITLE
Support test bundles under Xcode 7

### DIFF
--- a/Cedar.xcodeproj/project.pbxproj
+++ b/Cedar.xcodeproj/project.pbxproj
@@ -714,6 +714,13 @@
 		E32861331604F287001FA77E /* FibonacciCalculator.m in Sources */ = {isa = PBXBuildFile; fileRef = E32861311604F287001FA77E /* FibonacciCalculator.m */; };
 		E4BCFDD21817FA110083ED98 /* ObjectWithProperty.m in Sources */ = {isa = PBXBuildFile; fileRef = E4BCFDD11817FA110083ED98 /* ObjectWithProperty.m */; };
 		E4BCFDD31817FA110083ED98 /* ObjectWithProperty.m in Sources */ = {isa = PBXBuildFile; fileRef = E4BCFDD11817FA110083ED98 /* ObjectWithProperty.m */; };
+		F7F409981B2E3C8B001EFA14 /* CDRXCTestObserver.h in Headers */ = {isa = PBXBuildFile; fileRef = F7F409961B2E3C8B001EFA14 /* CDRXCTestObserver.h */; };
+		F7F409991B2E3C8B001EFA14 /* CDRXCTestObserver.h in Headers */ = {isa = PBXBuildFile; fileRef = F7F409961B2E3C8B001EFA14 /* CDRXCTestObserver.h */; };
+		F7F4099A1B2E3C8B001EFA14 /* CDRXCTestObserver.h in Headers */ = {isa = PBXBuildFile; fileRef = F7F409961B2E3C8B001EFA14 /* CDRXCTestObserver.h */; };
+		F7F4099B1B2E3C8B001EFA14 /* CDRXCTestObserver.m in Sources */ = {isa = PBXBuildFile; fileRef = F7F409971B2E3C8B001EFA14 /* CDRXCTestObserver.m */; };
+		F7F4099C1B2E3C8B001EFA14 /* CDRXCTestObserver.m in Sources */ = {isa = PBXBuildFile; fileRef = F7F409971B2E3C8B001EFA14 /* CDRXCTestObserver.m */; };
+		F7F4099D1B2E3C8B001EFA14 /* CDRXCTestObserver.m in Sources */ = {isa = PBXBuildFile; fileRef = F7F409971B2E3C8B001EFA14 /* CDRXCTestObserver.m */; };
+		F7F4099F1B2E3E46001EFA14 /* CDRPrivateFunctions.h in Headers */ = {isa = PBXBuildFile; fileRef = F7F4099E1B2E3E26001EFA14 /* CDRPrivateFunctions.h */; settings = {ATTRIBUTES = (Private, ); }; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -1209,6 +1216,9 @@
 		E32861311604F287001FA77E /* FibonacciCalculator.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = FibonacciCalculator.m; sourceTree = "<group>"; };
 		E4BCFDD01817FA110083ED98 /* ObjectWithProperty.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = ObjectWithProperty.h; sourceTree = "<group>"; };
 		E4BCFDD11817FA110083ED98 /* ObjectWithProperty.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = ObjectWithProperty.m; sourceTree = "<group>"; };
+		F7F409961B2E3C8B001EFA14 /* CDRXCTestObserver.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = CDRXCTestObserver.h; sourceTree = "<group>"; };
+		F7F409971B2E3C8B001EFA14 /* CDRXCTestObserver.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = CDRXCTestObserver.m; sourceTree = "<group>"; };
+		F7F4099E1B2E3E26001EFA14 /* CDRPrivateFunctions.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = CDRPrivateFunctions.h; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -1611,10 +1621,12 @@
 			isa = PBXGroup;
 			children = (
 				AE0C9D8B19C0C64200B4DD2B /* CDRSpec+XCTestSupport.m */,
-				AE31A29D19C0F23F00C438C1 /* CDRXTestSuite.h */,
-				AE31A29E19C0F23F00C438C1 /* CDRXTestSuite.m */,
 				AE34724919C37ECF005CA6F1 /* CDRXCTestCase.h */,
 				AE34724A19C37ECF005CA6F1 /* CDRXCTestCase.m */,
+				F7F409961B2E3C8B001EFA14 /* CDRXCTestObserver.h */,
+				F7F409971B2E3C8B001EFA14 /* CDRXCTestObserver.m */,
+				AE31A29D19C0F23F00C438C1 /* CDRXTestSuite.h */,
+				AE31A29E19C0F23F00C438C1 /* CDRXTestSuite.m */,
 				AE4E9B9019C8B44700D794CE /* NSInvocation+CDRXExample.h */,
 				AE4E9B9119C8B44700D794CE /* NSInvocation+CDRXExample.m */,
 			);
@@ -1896,29 +1908,30 @@
 		AEEE1FCA11DC27B800029872 /* Headers */ = {
 			isa = PBXGroup;
 			children = (
-				AEAA190F19DCC5A900194E95 /* Extensions */,
-				66F00B4F14C4D8F600146D88 /* Doubles */,
-				AEEE1FD411DC27B800029872 /* iPhone */,
-				AE0AF55D13E9C06900029396 /* Matchers */,
-				1FE15C241869092300207F0C /* Reporters */,
-				AEF8FB0619E6000E00DD4FE4 /* CDRVersion.h */,
+				3460489318F2DBBF00BC93B6 /* CDRBlockHelper.h */,
 				AEEE1FCC11DC27B800029872 /* CDRExample.h */,
 				AEEE1FCD11DC27B800029872 /* CDRExampleBase.h */,
 				AEEE1FCE11DC27B800029872 /* CDRExampleGroup.h */,
 				AEEE1FCF11DC27B800029872 /* CDRExampleParent.h */,
 				AEEE1FD111DC27B800029872 /* CDRFunctions.h */,
 				2234907C18009DA6001C8E8D /* CDRHooks.h */,
+				34F3DF7B1A6ABA2E003041DA /* CDRNil.h */,
 				96EA1CAD142C6449001A78E0 /* CDROTestRunner.h */,
+				F7F4099E1B2E3E26001EFA14 /* CDRPrivateFunctions.h */,
+				AE55BF1D19A7CF83005948E6 /* CDRRuntimeUtilities.h */,
 				AEFD17B311DD1E8200F4448A /* CDRSharedExampleGroupPool.h */,
 				AEEE1FD211DC27B800029872 /* CDRSpec.h */,
 				AE8C880E13626FA5006C9305 /* CDRSpecFailure.h */,
-				969B6F95160F1FEC00C7C792 /* CDRSymbolicator.h */,
-				AEEE1FD311DC27B800029872 /* Cedar.h */,
 				AEEE1FDB11DC27B800029872 /* CDRSpecHelper.h */,
-				3460489318F2DBBF00BC93B6 /* CDRBlockHelper.h */,
+				969B6F95160F1FEC00C7C792 /* CDRSymbolicator.h */,
 				34681C2D18FE4611009D38AC /* CDRTypeUtilities.h */,
-				AE55BF1D19A7CF83005948E6 /* CDRRuntimeUtilities.h */,
-				34F3DF7B1A6ABA2E003041DA /* CDRNil.h */,
+				AEF8FB0619E6000E00DD4FE4 /* CDRVersion.h */,
+				AEEE1FD311DC27B800029872 /* Cedar.h */,
+				66F00B4F14C4D8F600146D88 /* Doubles */,
+				AEAA190F19DCC5A900194E95 /* Extensions */,
+				AEEE1FD411DC27B800029872 /* iPhone */,
+				AE0AF55D13E9C06900029396 /* Matchers */,
+				1FE15C241869092300207F0C /* Reporters */,
 			);
 			path = Headers;
 			sourceTree = "<group>";
@@ -2152,6 +2165,7 @@
 				AE4865A71B0690AF005DB302 /* AnyInstanceArgument.h in Headers */,
 				AE4865A81B0690AF005DB302 /* ReturnValue.h in Headers */,
 				AE4865A91B0690AF005DB302 /* AnyArgument.h in Headers */,
+				F7F4099A1B2E3C8B001EFA14 /* CDRXCTestObserver.h in Headers */,
 				AE4865AA1B0690AF005DB302 /* AnyInstanceOfClassArgument.h in Headers */,
 				AE4865AB1B0690AF005DB302 /* AnyInstanceConformingToProtocolArgument.h in Headers */,
 				AE4865AC1B0690AF005DB302 /* CDRProtocolFake.h in Headers */,
@@ -2217,6 +2231,7 @@
 				AE4865F21B069353005DB302 /* UIKitComparatorsContainer.h in Headers */,
 				AE4865121B06769B005DB302 /* NSMethodSignature+Cedar.h in Headers */,
 				AE4865E31B0690B2005DB302 /* CDRBlockHelper.h in Headers */,
+				F7F4099F1B2E3E46001EFA14 /* CDRPrivateFunctions.h in Headers */,
 				AE4865E51B0690B2005DB302 /* CDRNil.h in Headers */,
 				AE4865231B06769B005DB302 /* CedarDoubleImpl.h in Headers */,
 				AE48655D1B06769E005DB302 /* CDROTestRunner.h in Headers */,
@@ -2272,6 +2287,7 @@
 				AE18A7CE13F453CC00C8872C /* BeSameInstanceAs.h in Headers */,
 				AEF8FB0719E6000E00DD4FE4 /* CDRVersion.h in Headers */,
 				B86B685F1A1326E200F283F7 /* OSXGeometryStringifiers.h in Headers */,
+				F7F409981B2E3C8B001EFA14 /* CDRXCTestObserver.h in Headers */,
 				2234907D18009DA6001C8E8D /* CDRHooks.h in Headers */,
 				AE3E8F37184FEEE000633740 /* ObjectWithCollections.h in Headers */,
 				AE18A7CF13F453CC00C8872C /* BeTruthy.h in Headers */,
@@ -2340,6 +2356,7 @@
 				AE31A2A019C0F23F00C438C1 /* CDRXTestSuite.h in Headers */,
 				AEC9DEEF12C2CC7E0039512D /* CDRColorizedReporter.h in Headers */,
 				AE4E9B9319C8B44700D794CE /* NSInvocation+CDRXExample.h in Headers */,
+				F7F409991B2E3C8B001EFA14 /* CDRXCTestObserver.h in Headers */,
 				42064467139B44EC00C85605 /* CDRTeamCityReporter.h in Headers */,
 				AE34724C19C37ECF005CA6F1 /* CDRXCTestCase.h in Headers */,
 				96EA1CAF142C6449001A78E0 /* CDROTestReporter.h in Headers */,
@@ -2615,7 +2632,7 @@
 		AEEE1FA611DC26EA00029872 /* Project object */ = {
 			isa = PBXProject;
 			attributes = {
-				LastTestingUpgradeCheck = 0610;
+				LastTestingUpgradeCheck = 0700;
 				LastUpgradeCheck = 0610;
 				ORGANIZATIONNAME = Pivotal;
 				TargetAttributes = {
@@ -3046,6 +3063,7 @@
 				AE48657C1B067953005DB302 /* HaveReceived.mm in Sources */,
 				AE48657D1B067953005DB302 /* CDRSpyInfo.mm in Sources */,
 				AE48657E1B067953005DB302 /* NSInvocation+Cedar.m in Sources */,
+				F7F4099D1B2E3C8B001EFA14 /* CDRXCTestObserver.m in Sources */,
 				AE48657F1B067953005DB302 /* NSMethodSignature+Cedar.m in Sources */,
 				AE4865801B067953005DB302 /* CDRSpec+XCTestSupport.m in Sources */,
 				AE4865811B067953005DB302 /* CDRXTestSuite.m in Sources */,
@@ -3104,6 +3122,7 @@
 				AEEE1FF611DC27B800029872 /* CDRExampleGroup.m in Sources */,
 				AEEE1FF711DC27B800029872 /* CDRFunctions.m in Sources */,
 				AEEE1FF811DC27B800029872 /* CDRSpec.m in Sources */,
+				F7F4099B1B2E3C8B001EFA14 /* CDRXCTestObserver.m in Sources */,
 				AEEE201111DC27B800029872 /* CDRSpecHelper.m in Sources */,
 				1FF449B118A0C03800AF94B0 /* CDRBufferedDefaultReporter.m in Sources */,
 				AEFD17BB11DD1E9E00F4448A /* CDRSharedExampleGroupPool.m in Sources */,
@@ -3230,6 +3249,7 @@
 				1FF4497E18A0B37A00AF94B0 /* AnyArgument.mm in Sources */,
 				AE4E9B9519C8B44700D794CE /* NSInvocation+CDRXExample.m in Sources */,
 				AE9855AE1236E7080024094E /* CDRSharedExampleGroupPool.m in Sources */,
+				F7F4099C1B2E3C8B001EFA14 /* CDRXCTestObserver.m in Sources */,
 				AEC9DEF412C2CC8F0039512D /* CDRColorizedReporter.m in Sources */,
 				1F483E34187D3CD200521F81 /* CDROTestNamer.m in Sources */,
 				4206446B139B44F600C85605 /* CDRTeamCityReporter.m in Sources */,

--- a/Source/CDRFunctions.m
+++ b/Source/CDRFunctions.m
@@ -362,83 +362,16 @@ int CDRRunSpecs() {
     }
 }
 
-#pragma mark - Running Test Bundles
-#import "CDRXTestSuite.h"
-#import "CDRRuntimeUtilities.h"
-
-@interface CDRXCTestSupport : NSObject
-- (id)testSuiteWithName:(NSString *)name;
-- (id)defaultTestSuite;
-- (id)initWithName:(NSString *)aName;
-
-- (id)CDR_original_defaultTestSuite;
-
-- (void)addTest:(id)test;
-@end
-
-static id CDRCreateXCTestSuite() {
-    Class testSuiteClass = NSClassFromString(@"XCTestSuite") ?: NSClassFromString(@"SenTestSuite");
-    Class testSuiteSubclass = NSClassFromString(@"_CDRXTestSuite");
-
-    if (testSuiteSubclass == nil) {
-        size_t size = class_getInstanceSize([CDRXTestSuite class]) - class_getInstanceSize([NSObject class]);
-        testSuiteSubclass = objc_allocateClassPair(testSuiteClass, "_CDRXTestSuite", size);
-        CDRCopyClassInternalsFromClass([CDRXTestSuite class], testSuiteSubclass);
-        objc_registerClassPair(testSuiteSubclass);
-    }
-
-    id testSuite = [[[(id)testSuiteSubclass alloc] initWithName:@"Cedar"] autorelease];
-    CDRDefineSharedExampleGroups();
-    CDRDefineGlobalBeforeAndAfterEachBlocks();
-
-    unsigned int seed = CDRGetRandomSeed();
-
-    NSArray *specClasses = CDRSpecClassesToRun();
-    NSArray *permutedSpecClasses = CDRPermuteSpecClassesWithSeed(specClasses, seed);
-    NSArray *specs = CDRSpecsFromSpecClasses(permutedSpecClasses);
-    CDRMarkFocusedExamplesInSpecs(specs);
-    CDRMarkXcodeFocusedExamplesInSpecs(specs, [[NSProcessInfo processInfo] arguments]);
-
-    CDRReportDispatcher *dispatcher = [[[CDRReportDispatcher alloc] initWithReporters:CDRReportersToRun()] autorelease];
-
-    [testSuite setDispatcher:dispatcher];
-
-    NSArray *groups = CDRRootGroupsFromSpecs(specs);
-    [dispatcher runWillStartWithGroups:groups andRandomSeed:seed];
-
-    for (CDRSpec *spec in specs) {
-        [testSuite addTest:[spec testSuiteWithRandomSeed:seed dispatcher:dispatcher]];
-    }
-    return testSuite;
-}
-
-void CDRInjectIntoXCTestRunner() {
-    Class testSuiteClass = NSClassFromString(@"XCTestSuite") ?: NSClassFromString(@"SenTestSuite");
-
-    if (!testSuiteClass) {
-        [[NSException exceptionWithName:@"CedarNoTestFrameworkAvailable" reason:@"You must link against either XCTest or SenTestingKit frameworks." userInfo:nil] raise];
-    }
-
-    Class testSuiteMetaClass = object_getClass(testSuiteClass);
-    Method m = class_getClassMethod(testSuiteClass, @selector(defaultTestSuite));
-    class_addMethod(testSuiteMetaClass, @selector(CDR_original_defaultTestSuite), method_getImplementation(m), method_getTypeEncoding(m));
-    IMP newImp = imp_implementationWithBlock(^id(id self){
-        id defaultSuite = [self CDR_original_defaultTestSuite];
-        [defaultSuite addTest:CDRCreateXCTestSuite()];
-        return defaultSuite;
-    });
-    class_replaceMethod(testSuiteMetaClass, @selector(defaultTestSuite), newImp, method_getTypeEncoding(m));
-}
-
 NSString *CDRGetTestBundleExtension() {
     NSString *extension = nil;;
-
     NSArray *arguments = [[NSProcessInfo processInfo] arguments];
     NSSet *xctestFlags = [NSSet setWithArray:@[@"-XCTest", @"-XCTestScopeFile"]];
     if ([xctestFlags intersectsSet:[NSSet setWithArray:arguments]]) {
         extension = @".xctest";
     } else if ([arguments containsObject:@"-SenTest"]) {
         extension = @".octest";
+    } else if ((BOOL)NSClassFromString(@"XCTestCase")) {
+        extension = @".xctest";
     }
 
     return extension;

--- a/Source/Headers/CDRPrivateFunctions.h
+++ b/Source/Headers/CDRPrivateFunctions.h
@@ -1,0 +1,19 @@
+#import <Foundation/Foundation.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+    void CDRMarkXcodeFocusedExamplesInSpecs(NSArray *specs, NSArray *arguments);
+    void CDRMarkFocusedExamplesInSpecs(NSArray *specs);
+    NSArray *CDRSpecsFromSpecClasses(NSArray *specClasses);
+    void CDRDefineSharedExampleGroups();
+    void CDRDefineGlobalBeforeAndAfterEachBlocks();
+    unsigned int CDRGetRandomSeed();
+    NSArray *CDRSpecClassesToRun();
+    NSArray *CDRRootGroupsFromSpecs(NSArray *specs);
+    NSArray *CDRPermuteSpecClassesWithSeed(NSArray *unsortedSpecClasses, unsigned int seed);
+    
+#ifdef __cplusplus
+}
+#endif

--- a/Source/iPhone/XCTest/CDRXCTestObserver.h
+++ b/Source/iPhone/XCTest/CDRXCTestObserver.h
@@ -1,0 +1,20 @@
+#import <Foundation/Foundation.h>
+
+@class XCTestSuite;
+@protocol XCTestObservation
+- (void)testSuiteWillStart:(XCTestSuite *)testSuite;
+@end
+
+@class XCTestObservationCenter;
+@interface XCTestObservationCenter
+@end
+
+@interface XCTestObservationCenter (CDRVisibility)
++ (instancetype)sharedTestObservationCenter;
+- (void)addTestObserver:(id<XCTestObservation>)observer;
+- (void)removeTestObserver:(id<XCTestObservation>)observer;
+@end
+
+@interface CDRXCTestObserver : NSObject <XCTestObservation>
+
+@end

--- a/Source/iPhone/XCTest/CDRXCTestObserver.m
+++ b/Source/iPhone/XCTest/CDRXCTestObserver.m
@@ -1,0 +1,111 @@
+#import "CDRXCTestObserver.h"
+#import "CDRFunctions.h"
+#import "CDRPrivateFunctions.h"
+#import "CDRReportDispatcher.h"
+#import "CDRSpec.h"
+#import <objc/runtime.h>
+
+#pragma mark - Running Test Bundles
+#import "CDRXTestSuite.h"
+#import "CDRRuntimeUtilities.h"
+
+@interface CDRXCTestObserver ()
+@property (assign) BOOL observedTestSuiteStart;
+@end
+
+@interface CDRXCTestSupport : NSObject
+- (id)testSuiteWithName:(NSString *)name;
+- (id)defaultTestSuite;
+- (id)testSuiteForBundlePath:(NSString *)bundlePath;
+- (id)initWithName:(NSString *)aName;
+
+- (id)CDR_original_defaultTestSuite;
+
+- (void)addTest:(id)test;
+@end
+
+@implementation CDRXCTestObserver
+
+- (void)testSuiteWillStart:(XCTestSuite *)testSuite {
+    if (self.observedTestSuiteStart) {
+        return;
+    }
+
+    unsigned int seed = CDRGetRandomSeed();
+    NSArray *specClasses = CDRSpecClassesToRun();
+    NSArray *permutedSpecClasses = CDRPermuteSpecClassesWithSeed(specClasses, seed);
+    NSArray *specs = CDRSpecsFromSpecClasses(permutedSpecClasses);
+    CDRReportDispatcher *dispatcher = [[[CDRReportDispatcher alloc] initWithReporters:CDRReportersToRun()] autorelease];
+    for (CDRSpec *spec in specs) {
+        [testSuite addTest:[spec testSuiteWithRandomSeed:seed dispatcher:dispatcher]];
+    }
+
+    self.observedTestSuiteStart = YES;
+}
+
+@end
+
+static id CDRCreateXCTestSuite() {
+    Class testSuiteClass = NSClassFromString(@"XCTestSuite") ?: NSClassFromString(@"SenTestSuite");
+    Class testSuiteSubclass = NSClassFromString(@"_CDRXTestSuite");
+
+    if (testSuiteSubclass == nil) {
+        size_t size = class_getInstanceSize([CDRXTestSuite class]) - class_getInstanceSize([NSObject class]);
+        testSuiteSubclass = objc_allocateClassPair(testSuiteClass, "_CDRXTestSuite", size);
+        CDRCopyClassInternalsFromClass([CDRXTestSuite class], testSuiteSubclass);
+        objc_registerClassPair(testSuiteSubclass);
+    }
+
+    id testSuite = [[[(id)testSuiteSubclass alloc] initWithName:@"Cedar"] autorelease];
+    CDRDefineSharedExampleGroups();
+    CDRDefineGlobalBeforeAndAfterEachBlocks();
+
+    unsigned int seed = CDRGetRandomSeed();
+
+    NSArray *specClasses = CDRSpecClassesToRun();
+    NSArray *permutedSpecClasses = CDRPermuteSpecClassesWithSeed(specClasses, seed);
+    NSArray *specs = CDRSpecsFromSpecClasses(permutedSpecClasses);
+    CDRMarkFocusedExamplesInSpecs(specs);
+    CDRMarkXcodeFocusedExamplesInSpecs(specs, [[NSProcessInfo processInfo] arguments]);
+
+    CDRReportDispatcher *dispatcher = [[[CDRReportDispatcher alloc] initWithReporters:CDRReportersToRun()] autorelease];
+
+    [testSuite setDispatcher:dispatcher];
+
+    NSArray *groups = CDRRootGroupsFromSpecs(specs);
+    [dispatcher runWillStartWithGroups:groups andRandomSeed:seed];
+
+    for (CDRSpec *spec in specs) {
+        [testSuite addTest:[spec testSuiteWithRandomSeed:seed dispatcher:dispatcher]];
+    }
+    return testSuite;
+}
+
+void CDRInjectIntoXCTestRunner() {
+    // if possible, use the new XCTestObservation protocol
+    // this is only available starting with iOS 9 and OSX 10.11
+    Class observationCenterClass = NSClassFromString(@"XCTestObservationCenter");
+    if (observationCenterClass && [observationCenterClass respondsToSelector:@selector(sharedTestObservationCenter)]) {
+        id observationCenter = [observationCenterClass performSelector:@selector(sharedTestObservationCenter)];
+        static CDRXCTestObserver *xcTestObserver;
+        xcTestObserver = [[CDRXCTestObserver alloc] init];
+        [observationCenter addTestObserver:xcTestObserver];
+        return;
+    }
+
+    Class testSuiteClass = NSClassFromString(@"XCTestSuite") ?: NSClassFromString(@"SenTestSuite");
+    if (!testSuiteClass) {
+        [[NSException exceptionWithName:@"CedarNoTestFrameworkAvailable" reason:@"You must link against either the XCTest or SenTestingKit frameworks." userInfo:nil] raise];
+    }
+
+    Class testSuiteMetaClass = object_getClass(testSuiteClass);
+    Method m = class_getClassMethod(testSuiteClass, @selector(defaultTestSuite));
+
+    class_addMethod(testSuiteMetaClass, @selector(CDR_original_defaultTestSuite), method_getImplementation(m), method_getTypeEncoding(m));
+    IMP newImp = imp_implementationWithBlock(^id(id self){
+        id defaultSuite = [self CDR_original_defaultTestSuite];
+        [defaultSuite addTest:CDRCreateXCTestSuite()];
+        return defaultSuite;
+    });
+    class_replaceMethod(testSuiteMetaClass, @selector(defaultTestSuite), newImp, method_getTypeEncoding(m));
+}

--- a/Spec/CDRSpecFailureSpec.mm
+++ b/Spec/CDRSpecFailureSpec.mm
@@ -93,12 +93,14 @@ describe(@"CDRSpecFailure", ^{
             context(@"when file name and line number are specified in exception's userInfo", ^{
                 beforeEach(^{
                     NSDictionary *userInfo = [NSDictionary dictionaryWithObjectsAndKeys:@"File.m", @"fileName", [NSNumber numberWithInt:123], @"lineNumber", nil];
-                    NSException *exception = [NSException exceptionWithName:@"boo" reason:@"exception reason" userInfo:userInfo];
+                    NSException *exception = [NSException exceptionWithName:@"name"
+                                                                     reason:@"reason"
+                                                                   userInfo:userInfo];
                     failure = [CDRSpecFailure specFailureWithRaisedObject:exception];
                 });
 
                 it(@"should return exception's reason", ^{
-                    expect([failure reason]).to(equal(@"exception reason"));
+                    expect([failure reason]).to(equal(@"reason"));
                 });
 
                 it(@"should return file name specified in exception's userInfo", ^{
@@ -112,12 +114,14 @@ describe(@"CDRSpecFailure", ^{
 
             context(@"when file name and line number are not specified in userInfo of exception", ^{
                 beforeEach(^{
-                    NSException *exception = [NSException exceptionWithName:@"boo" reason:@"exception reason" userInfo:nil];
+                    NSException *exception = [NSException exceptionWithName:@"name"
+                                                                     reason:@"reason"
+                                                                   userInfo:nil];
                     failure = [CDRSpecFailure specFailureWithRaisedObject:exception];
                 });
 
                 it(@"should return raised object's reason", ^{
-                    expect([failure reason]).to(equal(@"exception reason"));
+                    expect([failure reason]).to(equal(@"reason"));
                 });
 
                 it(@"should return nil for file name", ^{
@@ -193,8 +197,8 @@ describe(@"CDRSpecFailure", ^{
                     it(@"returns string with symbolicated call stack "
                         "showing originating error location closest to the top", ^{
                          symbols should contain(
-                            @"  *CDRSpecFailureSpec.mm:165\n"
-                             "  *CDRSpecFailureSpec.mm:171\n"
+                            @"  *CDRSpecFailureSpec.mm:169\n"
+                             "  *CDRSpecFailureSpec.mm:175\n"
                         );
                     });
 

--- a/Spec/Doubles/CedarDoubleARCSharedExamples.mm
+++ b/Spec/Doubles/CedarDoubleARCSharedExamples.mm
@@ -27,6 +27,7 @@ sharedExamplesFor(@"a Cedar double when used with ARC", ^(NSDictionary *sharedCo
                     runBlock();
                     called = true;
                 });
+                myDouble stub_method(@selector(value));
 
                 dispatch_group_t group = dispatch_group_create();
                 dispatch_queue_t queue = dispatch_get_global_queue(DISPATCH_QUEUE_PRIORITY_HIGH, 0);


### PR DESCRIPTION
I'd like to submit this pull request early and solicit feedback, rather than continue to work on this in isolation. 

This pull request continues the bold tradition of not explicitly linking against XCTest, and tests for the presence of the `XCTestObservationCenter` class, which I understand to not be available prior to the current Xcode 7 beta (7A120f). Granted, I didn't add any new specs for this behavior, I believe the existing iOS app that links against XCTest is sufficient, but I'd love to spend some time thinking about how we could have better test coverage here.

I've also attempted to contain some of the craziness around setting up our XCTest observer, of which there can only be a single one. I couldn't find an easy way of hooking into a TestBundle starting, but I found that attaching to a test suite starting was sufficient, although since adding specs there implicitly adds ANOTHER named suite, we need to guard against running in an infinite loop here. It seems like we should be able to observer `testSuiteDidStart:` and `testSuiteDidFinish:` but, it seems like `testSuiteDidFinish:` is never called when an observer continues to add new tests in each `testSuiteDidStart:` action.

Also of note, some of the private functions we had been using to bootstrap the insane XCTest subclass creation moved around, and were exposed in a private header.

Fixes #333 (at least, it runs the specs).