### PR TITLE
Produce an explicit error if Cedar is imported from a non-C++ source file

### DIFF
--- a/Source/Headers/Cedar.h
+++ b/Source/Headers/Cedar.h
@@ -1,3 +1,7 @@
+#ifndef __cplusplus
+#error Cedar may only be imported from Objective-C++ (.mm) files.
+#endif
+
 #import "CDRFunctions.h"
 #import "CDRSpecHelper.h"
 


### PR DESCRIPTION
This seems like an easy way to reduce the pain that future users will inevitably have when inadvertently importing Cedar in places where it doesn't belong. (Cf. #341)

Any objections?