### PR TITLE
Adds -sent_messages_with_selector: to <CedarDouble>

### DIFF
--- a/Source/Doubles/CDRFake.mm
+++ b/Source/Doubles/CDRFake.mm
@@ -85,6 +85,10 @@
     return self.cedar_double_impl.sent_messages;
 }
 
+- (NSArray *)sent_messages_with_selector:(SEL)selector {
+    return [self.cedar_double_impl sent_messages_with_selector:selector];
+}
+
 - (void)reset_sent_messages {
     [self.cedar_double_impl reset_sent_messages];
 }

--- a/Source/Doubles/CDRSpy.mm
+++ b/Source/Doubles/CDRSpy.mm
@@ -187,6 +187,11 @@
     return self.cedar_double_impl.sent_messages;
 }
 
+- (NSArray *)sent_messages_with_selector:(SEL)selector
+{
+    return [self.cedar_double_impl sent_messages_with_selector:selector];
+}
+
 - (void)reset_sent_messages {
     [self.cedar_double_impl reset_sent_messages];
 }

--- a/Source/Doubles/CedarDoubleImpl.mm
+++ b/Source/Doubles/CedarDoubleImpl.mm
@@ -46,6 +46,19 @@ static NSMutableArray *registeredDoubleImpls__ = nil;
     [super dealloc];
 }
 
+- (NSArray *)sent_messages_with_selector:(SEL)selector
+{
+    NSMutableArray *sentMessages = [[NSMutableArray alloc] initWithCapacity:self.sent_messages.count];
+
+    for(NSInvocation *invocation in self.sent_messages) {
+        if (invocation.selector == selector) {
+            [sentMessages addObject:invocation];
+        }
+    }
+    
+    return [sentMessages copy];
+}
+
 - (void)reset_sent_messages {
     [self.sent_messages removeAllObjects];
 }

--- a/Source/Headers/Doubles/CedarDouble.h
+++ b/Source/Headers/Doubles/CedarDouble.h
@@ -11,6 +11,7 @@ namespace Cedar { namespace Doubles {
 - (void)reject_method:(const Cedar::Doubles::RejectedMethod &)rejected_method;
 
 - (NSArray *)sent_messages;
+- (NSArray *)sent_messages_with_selector:(SEL)selector;
 - (void)reset_sent_messages;
 
 - (BOOL)can_stub:(SEL)selector;

--- a/Spec/Doubles/CedarDoubleSharedExamples.mm
+++ b/Spec/Doubles/CedarDoubleSharedExamples.mm
@@ -27,6 +27,36 @@ sharedExamplesFor(@"a Cedar double", ^(NSDictionary *sharedContext) {
             [[myDouble sent_messages] count] should equal(1);
         });
     });
+    
+    describe(@"sent_messages_with_selector", ^{
+        beforeEach(^{
+            myDouble stub_method("incrementBy:");
+            myDouble stub_method("incrementByInteger:");
+
+            [myDouble incrementByInteger:1];
+            [myDouble incrementBy:2];
+            [myDouble incrementByInteger:3];
+            [myDouble incrementBy:4];
+            [myDouble incrementByInteger:5];
+        });
+        
+        it(@"should return all invocations for messages sent that match the given selector", ^{
+            NSArray *sentMessages = [myDouble sent_messages_with_selector:@selector(incrementBy:)];
+            sentMessages.count should equal(2);
+            
+            NSInvocation *firstInvocation = sentMessages.firstObject;
+            firstInvocation.selector should equal(@selector(incrementBy:));
+            NSUInteger firstIncrement;
+            [firstInvocation getArgument:&firstIncrement atIndex:2];
+            firstIncrement should equal(2);
+            
+            NSInvocation *secondInvocation = sentMessages.lastObject;
+            secondInvocation.selector should equal(@selector(incrementBy:));
+            NSUInteger secondIncrement;
+            [secondInvocation getArgument:&secondIncrement atIndex:2];
+            secondIncrement should equal(4);
+        });
+    });
 
     context(@"where the expected type is a char * and a char * is passed", ^{
         it(@"should just work", ^{


### PR DESCRIPTION
This allows you to ask the double for all invocations that exactly match
a given selector.

This is something that I've often had to write my own code for which
iterates through invocations and plucks out the correct ones.