### PR TITLE
Stop testing iOS 7.0.3 on Travis CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,14 +1,17 @@
 language: objective-c
+osx_image: xcode6.4
 
 env:
   matrix:
-    - CEDAR_SDK_VERSION="8.1" CEDAR_SDK_RUNTIME_VERSION="7.0.3" TASK="ci"
-    - CEDAR_SDK_VERSION="8.1" CEDAR_SDK_RUNTIME_VERSION="7.1" TASK="ci"
-    - CEDAR_SDK_VERSION="8.1" CEDAR_SDK_RUNTIME_VERSION="8.1" TASK="ci"
+    - CEDAR_SDK_VERSION="8.3" CEDAR_SDK_RUNTIME_VERSION="7.1" TASK="ci"
+    - CEDAR_SDK_VERSION="8.3" CEDAR_SDK_RUNTIME_VERSION="8.1" TASK="ci"
+    - CEDAR_SDK_VERSION="8.3" CEDAR_SDK_RUNTIME_VERSION="8.3" TASK="ci"
+    - CEDAR_SDK_VERSION="8.3" CEDAR_SDK_RUNTIME_VERSION="8.4" TASK="ci"
+
     # Analyze takes too long -- vary on runtime SDK
-    - CEDAR_SDK_VERSION="8.1" CEDAR_SDK_RUNTIME_VERSION="8.1" TASK="suites:specs:analyze"
-    - CEDAR_SDK_VERSION="8.1" CEDAR_SDK_RUNTIME_VERSION="8.1" TASK="suites:uispecs:analyze"
-    - CEDAR_SDK_VERSION="8.1" CEDAR_SDK_RUNTIME_VERSION="8.1" TASK="suites:focused_specs:analyze"
+    - CEDAR_SDK_VERSION="8.3" CEDAR_SDK_RUNTIME_VERSION="8.3" TASK="suites:specs:analyze"
+    - CEDAR_SDK_VERSION="8.3" CEDAR_SDK_RUNTIME_VERSION="8.3" TASK="suites:uispecs:analyze"
+    - CEDAR_SDK_VERSION="8.3" CEDAR_SDK_RUNTIME_VERSION="8.3" TASK="suites:focused_specs:analyze"
 
 before_install: brew update
 install:


### PR DESCRIPTION
Adds 8.3 and 8.4 tasks to the Travis Matrix.

Thought that this might be a controversial change and that a pull request would be best.