### PR TITLE
Fix crash when adding a block stub to certain methods

### DIFF
--- a/Source/Extensions/NSMethodSignature+Cedar.m
+++ b/Source/Extensions/NSMethodSignature+Cedar.m
@@ -18,14 +18,16 @@ static const char *Block_signature(id blockObj) {
     const char *signatureTypes = Block_signature(block);
     NSString *signatureTypesString = [NSString stringWithUTF8String:signatureTypes];
 
-    NSRegularExpression *quotedSubstringsRegex = [NSRegularExpression
-                                                  regularExpressionWithPattern:@"(\".*?\")|(<.*?>)"
-                                                  options:NSRegularExpressionCaseInsensitive
-                                                  error:NULL];
+    NSString *quotedSubstringsPattern = @"\".*?\"";
+    NSString *angleBracketedSubstringsPattern = @"<.*?>";
 
-    NSString *strippedSignatureTypesString = [quotedSubstringsRegex stringByReplacingMatchesInString:signatureTypesString options:0 range:NSMakeRange(0, [signatureTypesString length]) withTemplate:@""];
+    NSString *strippedSignatureTypeString = signatureTypesString;
+    for (NSString *pattern in @[quotedSubstringsPattern, angleBracketedSubstringsPattern]) {
+        NSRegularExpression *regex = [NSRegularExpression regularExpressionWithPattern:pattern options:NSRegularExpressionCaseInsensitive error:NULL];
+        strippedSignatureTypeString = [regex stringByReplacingMatchesInString:strippedSignatureTypeString options:0 range:NSMakeRange(0, [strippedSignatureTypeString length]) withTemplate:@""];
+    }
 
-    return [NSMethodSignature signatureWithObjCTypes:[strippedSignatureTypesString UTF8String]];
+    return [NSMethodSignature signatureWithObjCTypes:[strippedSignatureTypeString UTF8String]];
 }
 
 - (NSMethodSignature *)signatureWithoutSelectorArgument {

--- a/Spec/Doubles/CedarDoubleSharedExamples.mm
+++ b/Spec/Doubles/CedarDoubleSharedExamples.mm
@@ -393,7 +393,7 @@ sharedExamplesFor(@"a Cedar double", ^(NSDictionary *sharedContext) {
             });
 
             context(@"with a valid block that takes a complex block as a parameter", ^{
-                ComplexIncrementerBlock sent_argument = ^LargeIncrementerStruct(NSNumber *, LargeIncrementerStruct, NSError *){ return (LargeIncrementerStruct){}; };
+                ComplexIncrementerBlock sent_argument = ^LargeIncrementerStruct(NSNumber *, LargeIncrementerStruct, id<NSCoding>){ return (LargeIncrementerStruct){}; };
                 __block ComplexIncrementerBlock received_argument;
 
                 beforeEach(^{

--- a/Spec/Support/SimpleIncrementer.h
+++ b/Spec/Support/SimpleIncrementer.h
@@ -4,7 +4,7 @@ typedef struct {
     size_t a, b, c, d;
 } LargeIncrementerStruct;
 
-typedef LargeIncrementerStruct (^ComplexIncrementerBlock)(NSNumber *, LargeIncrementerStruct, NSError *);
+typedef LargeIncrementerStruct (^ComplexIncrementerBlock)(NSNumber *, LargeIncrementerStruct, id<NSCoding>);
 
 @class FooSuperclass;
 


### PR DESCRIPTION
This happens for methods that take a block parameter that takes an object specified with a protocol.