### PR TITLE
Add a matcher for defining custom matchers using blocks

### DIFF
--- a/Cedar.xcodeproj/project.pbxproj
+++ b/Cedar.xcodeproj/project.pbxproj
@@ -225,6 +225,12 @@
 		346D1AAA1BBC41FE00BECD4B /* Foundation.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 346D1AA91BBC41FE00BECD4B /* Foundation.framework */; };
 		346D1AAB1BBC43E600BECD4B /* CDROTestReporterSpec.mm in Sources */ = {isa = PBXBuildFile; fileRef = 1F47B9A6186D69CD005A8CE1 /* CDROTestReporterSpec.mm */; };
 		346D1AAD1BBC46B600BECD4B /* QuartzCore.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 346D1AAC1BBC46B600BECD4B /* QuartzCore.framework */; };
+		346F646A1B82D01700F64156 /* BlockMatcher.h in Headers */ = {isa = PBXBuildFile; fileRef = 346F64681B82D01700F64156 /* BlockMatcher.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		346F646E1B82D3C900F64156 /* BlockMatcherSpec.mm in Sources */ = {isa = PBXBuildFile; fileRef = 346F646D1B82D3C900F64156 /* BlockMatcherSpec.mm */; };
+		346F646F1B82D3C900F64156 /* BlockMatcherSpec.mm in Sources */ = {isa = PBXBuildFile; fileRef = 346F646D1B82D3C900F64156 /* BlockMatcherSpec.mm */; };
+		346F64701B82D3C900F64156 /* BlockMatcherSpec.mm in Sources */ = {isa = PBXBuildFile; fileRef = 346F646D1B82D3C900F64156 /* BlockMatcherSpec.mm */; };
+		346F64741B82D90900F64156 /* BlockMatcher.h in Copy headers to framework */ = {isa = PBXBuildFile; fileRef = 346F64681B82D01700F64156 /* BlockMatcher.h */; };
+		346F64751B82D90C00F64156 /* BlockMatcher.h in Headers */ = {isa = PBXBuildFile; fileRef = 346F64681B82D01700F64156 /* BlockMatcher.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		34757E261BA4A48E0047BC8D /* TestObservationHelper.m in Sources */ = {isa = PBXBuildFile; fileRef = 34757E211BA466050047BC8D /* TestObservationHelper.m */; };
 		34777EB71B99451200A69FCF /* CDRPrivateFunctions.h in Headers */ = {isa = PBXBuildFile; fileRef = 34777EB61B99451200A69FCF /* CDRPrivateFunctions.h */; };
 		34852D151BBE35FF0072D249 /* main.m in Sources */ = {isa = PBXBuildFile; fileRef = 96B5FA04144A81A8000A6A5D /* main.m */; };
@@ -255,6 +261,12 @@
 		34ADD2EE19220F9300B057AC /* AnyInstanceConformingToProtocolArgument.h in Copy headers to framework */ = {isa = PBXBuildFile; fileRef = 34ADD2E41921F2F600B057AC /* AnyInstanceConformingToProtocolArgument.h */; };
 		34ADE41818F23C8E00BD1E99 /* NSMethodSignature+Cedar.m in Sources */ = {isa = PBXBuildFile; fileRef = 34ADE41618F23C8E00BD1E99 /* NSMethodSignature+Cedar.m */; };
 		34ADE41918F23E6B00BD1E99 /* NSMethodSignature+Cedar.m in Sources */ = {isa = PBXBuildFile; fileRef = 34ADE41618F23C8E00BD1E99 /* NSMethodSignature+Cedar.m */; };
+		34D1819C1BC7F0E60087EC0D /* BlockMatcher.h in Headers */ = {isa = PBXBuildFile; fileRef = 346F64681B82D01700F64156 /* BlockMatcher.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		34D1819D1BC7F0E70087EC0D /* BlockMatcher.h in Headers */ = {isa = PBXBuildFile; fileRef = 346F64681B82D01700F64156 /* BlockMatcher.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		34D1819E1BC7F0FD0087EC0D /* BlockMatcherSpec.mm in Sources */ = {isa = PBXBuildFile; fileRef = 346F646D1B82D3C900F64156 /* BlockMatcherSpec.mm */; };
+		34D1819F1BC7F0FD0087EC0D /* BlockMatcher_ARCSpecSpec.mm in Sources */ = {isa = PBXBuildFile; fileRef = AE0BF06E1B8E10D7000B0EE7 /* BlockMatcher_ARCSpecSpec.mm */; settings = {COMPILER_FLAGS = "-fobjc-arc"; }; };
+		34D181A01BC7F0FF0087EC0D /* BlockMatcherSpec.mm in Sources */ = {isa = PBXBuildFile; fileRef = 346F646D1B82D3C900F64156 /* BlockMatcherSpec.mm */; };
+		34D181A11BC7F0FF0087EC0D /* BlockMatcher_ARCSpecSpec.mm in Sources */ = {isa = PBXBuildFile; fileRef = AE0BF06E1B8E10D7000B0EE7 /* BlockMatcher_ARCSpecSpec.mm */; settings = {COMPILER_FLAGS = "-fobjc-arc"; }; };
 		34D4B5C318F3AE0400FB2C3B /* UIKitContainSpec.mm in Sources */ = {isa = PBXBuildFile; fileRef = 34D4B5C118F3ADFF00FB2C3B /* UIKitContainSpec.mm */; };
 		34D7C3C01BB970DF00E8E523 /* CDRXCTestFunctions.m in Sources */ = {isa = PBXBuildFile; fileRef = 3492DA961BA670C10032B35A /* CDRXCTestFunctions.m */; };
 		34D7C3C11BB970F100E8E523 /* CDRSpecRun.m in Sources */ = {isa = PBXBuildFile; fileRef = 3492DA9E1BA6F9E70032B35A /* CDRSpecRun.m */; };
@@ -616,6 +628,9 @@
 		AE0AF56C13E9C0FB00029396 /* CedarMatchers.h in Copy headers to framework */ = {isa = PBXBuildFile; fileRef = AE0AF55E13E9C0E300029396 /* CedarMatchers.h */; };
 		AE0AF58513E9E87E00029396 /* ActualValue.h in Headers */ = {isa = PBXBuildFile; fileRef = AE0AF58413E9E87E00029396 /* ActualValue.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		AE0AF58613E9E89D00029396 /* ActualValue.h in Copy headers to framework */ = {isa = PBXBuildFile; fileRef = AE0AF58413E9E87E00029396 /* ActualValue.h */; };
+		AE0BF06F1B8E10D8000B0EE7 /* BlockMatcher_ARCSpecSpec.mm in Sources */ = {isa = PBXBuildFile; fileRef = AE0BF06E1B8E10D7000B0EE7 /* BlockMatcher_ARCSpecSpec.mm */; settings = {COMPILER_FLAGS = "-fobjc-arc"; }; };
+		AE0BF0701B8E10D8000B0EE7 /* BlockMatcher_ARCSpecSpec.mm in Sources */ = {isa = PBXBuildFile; fileRef = AE0BF06E1B8E10D7000B0EE7 /* BlockMatcher_ARCSpecSpec.mm */; settings = {COMPILER_FLAGS = "-fobjc-arc"; }; };
+		AE0BF0711B8E10D8000B0EE7 /* BlockMatcher_ARCSpecSpec.mm in Sources */ = {isa = PBXBuildFile; fileRef = AE0BF06E1B8E10D7000B0EE7 /* BlockMatcher_ARCSpecSpec.mm */; settings = {COMPILER_FLAGS = "-fobjc-arc"; }; };
 		AE0C9D8E19C0C64200B4DD2B /* CDRSpec+XCTestSupport.m in Sources */ = {isa = PBXBuildFile; fileRef = AE0C9D8B19C0C64200B4DD2B /* CDRSpec+XCTestSupport.m */; };
 		AE0C9D8F19C0C64200B4DD2B /* CDRSpec+XCTestSupport.m in Sources */ = {isa = PBXBuildFile; fileRef = AE0C9D8B19C0C64200B4DD2B /* CDRSpec+XCTestSupport.m */; };
 		AE0F354719E7059D00B9F116 /* OSXGeometryCompareEqual.h in Headers */ = {isa = PBXBuildFile; fileRef = AE0F354619E7059200B9F116 /* OSXGeometryCompareEqual.h */; settings = {ATTRIBUTES = (Public, ); }; };
@@ -1316,6 +1331,7 @@
 				AE74907515B493B6008EA127 /* CDRFake.h in Copy headers to framework */,
 				AECF136215D1425C003AAB9C /* Argument.h in Copy headers to framework */,
 				AECF136515D14274003AAB9C /* ValueArgument.h in Copy headers to framework */,
+				346F64741B82D90900F64156 /* BlockMatcher.h in Copy headers to framework */,
 				AECF136815D142E3003AAB9C /* ReturnValue.h in Copy headers to framework */,
 				AE9BA627184D203000079A97 /* ConformTo.h in Copy headers to framework */,
 				AECF136B15D1439B003AAB9C /* AnyArgument.h in Copy headers to framework */,
@@ -1365,6 +1381,8 @@
 		346D1AA21BBB457900BECD4B /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
 		346D1AA91BBC41FE00BECD4B /* Foundation.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = Foundation.framework; path = System/Library/Frameworks/Foundation.framework; sourceTree = SDKROOT; };
 		346D1AAC1BBC46B600BECD4B /* QuartzCore.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = QuartzCore.framework; path = Platforms/iPhoneOS.platform/Developer/SDKs/iPhoneOS9.1.sdk/System/Library/Frameworks/QuartzCore.framework; sourceTree = DEVELOPER_DIR; };
+		346F64681B82D01700F64156 /* BlockMatcher.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = BlockMatcher.h; sourceTree = "<group>"; };
+		346F646D1B82D3C900F64156 /* BlockMatcherSpec.mm */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.objcpp; path = BlockMatcherSpec.mm; sourceTree = "<group>"; };
 		34757E201BA466050047BC8D /* TestObservationHelper.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = TestObservationHelper.h; sourceTree = "<group>"; };
 		34757E211BA466050047BC8D /* TestObservationHelper.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = TestObservationHelper.m; sourceTree = "<group>"; };
 		34777EB61B99451200A69FCF /* CDRPrivateFunctions.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = CDRPrivateFunctions.h; sourceTree = "<group>"; };
@@ -1446,6 +1464,7 @@
 		AE0AF55E13E9C0E300029396 /* CedarMatchers.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = CedarMatchers.h; sourceTree = "<group>"; };
 		AE0AF57913E9C16D00029396 /* MatcherTemplate.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = MatcherTemplate.h; sourceTree = "<group>"; };
 		AE0AF58413E9E87E00029396 /* ActualValue.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = ActualValue.h; sourceTree = "<group>"; };
+		AE0BF06E1B8E10D7000B0EE7 /* BlockMatcher_ARCSpecSpec.mm */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.objcpp; path = BlockMatcher_ARCSpecSpec.mm; sourceTree = "<group>"; };
 		AE0C9D8B19C0C64200B4DD2B /* CDRSpec+XCTestSupport.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = "CDRSpec+XCTestSupport.m"; sourceTree = "<group>"; };
 		AE0F354619E7059200B9F116 /* OSXGeometryCompareEqual.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = OSXGeometryCompareEqual.h; sourceTree = "<group>"; };
 		AE0F354819E705C700B9F116 /* OSXGeometryStringifiers.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = OSXGeometryStringifiers.h; sourceTree = "<group>"; };
@@ -2349,6 +2368,7 @@
 				AE0721E2187518FD0031CC42 /* Exist.h */,
 				AEB45A901496C8D800845D09 /* RaiseException.h */,
 				CA17998C17F89C4B00C38060 /* RespondTo.h */,
+				346F64681B82D01700F64156 /* BlockMatcher.h */,
 			);
 			path = Base;
 			sourceTree = "<group>";
@@ -2374,6 +2394,8 @@
 				AEF7301A13ECC4AE00786282 /* MutableEqualSpec.mm */,
 				AEBB92601496C1F000EEBD59 /* RaiseExceptionSpec.mm */,
 				CA17999217F8A0EE00C38060 /* RespondToSpec.mm */,
+				346F646D1B82D3C900F64156 /* BlockMatcherSpec.mm */,
+				AE0BF06E1B8E10D7000B0EE7 /* BlockMatcher_ARCSpecSpec.mm */,
 			);
 			path = Base;
 			sourceTree = "<group>";
@@ -2484,6 +2506,7 @@
 				346262191B99546C002CAEBD /* RespondTo.h in Headers */,
 				346261E81B995422002CAEBD /* CedarDoubleImpl.h in Headers */,
 				346262421B9954C1002CAEBD /* CDRVersion.h in Headers */,
+				34D1819C1BC7F0E60087EC0D /* BlockMatcher.h in Headers */,
 				346261FE1B995445002CAEBD /* AnyInstanceOfClassArgument.h in Headers */,
 				3462623A1B9954C1002CAEBD /* CDRExampleGroup.h in Headers */,
 				346261EA1B995422002CAEBD /* NSMethodSignature+Cedar.h in Headers */,
@@ -2622,6 +2645,7 @@
 				34D7C45B1BB9B5F100E8E523 /* CDRExampleParent.h in Headers */,
 				34D7C41C1BB9B56D00E8E523 /* ReturnValue.h in Headers */,
 				34D7C44E1BB9B5DF00E8E523 /* CedarComparators.h in Headers */,
+				34D1819D1BC7F0E70087EC0D /* BlockMatcher.h in Headers */,
 				34D7C42C1BB9B5A400E8E523 /* CedarApplicationDelegate.h in Headers */,
 				34D7C4471BB9B5C500E8E523 /* ComparatorsContainerConvenience.h in Headers */,
 				34D7C4561BB9B5E900E8E523 /* CDRTeamCityReporter.h in Headers */,
@@ -2680,6 +2704,7 @@
 				AE4865C71B0690B0005DB302 /* RespondTo.h in Headers */,
 				AE4865C81B0690B0005DB302 /* StringifiersBase.h in Headers */,
 				AE4865C91B0690B0005DB302 /* StringifiersContainer.h in Headers */,
+				346F64751B82D90C00F64156 /* BlockMatcher.h in Headers */,
 				AE4865CA1B0690B0005DB302 /* ComparatorsBase.h in Headers */,
 				AE4865CB1B0690B0005DB302 /* ComparatorsContainer.h in Headers */,
 				AE4865CC1B0690B0005DB302 /* CompareEqual.h in Headers */,
@@ -2828,6 +2853,7 @@
 				AECF136415D14274003AAB9C /* ValueArgument.h in Headers */,
 				AECF136715D142E3003AAB9C /* ReturnValue.h in Headers */,
 				AECF136A15D1439B003AAB9C /* AnyArgument.h in Headers */,
+				346F646A1B82D01700F64156 /* BlockMatcher.h in Headers */,
 				AE55BF1E19A7CFAB005948E6 /* CDRRuntimeUtilities.h in Headers */,
 				AE94D03F15F341B200A0C2B7 /* AnyInstanceArgument.h in Headers */,
 				AEE8DBD4175FFCF3008AF18A /* CDRSpyInfo.h in Headers */,
@@ -3495,6 +3521,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				34FD463B1B99D25000257186 /* ObjectWithValueEquality.m in Sources */,
+				34D181A11BC7F0FF0087EC0D /* BlockMatcher_ARCSpecSpec.mm in Sources */,
 				34FD465B1B99D2E300257186 /* CedarNiceFakeSharedExamples.mm in Sources */,
 				34FD46471B99D2B000257186 /* BeNilSpec.mm in Sources */,
 				34FD465C1B99D2E300257186 /* CedarOrdinaryFakeSharedExamples.mm in Sources */,
@@ -3503,6 +3530,7 @@
 				34FD46521B99D2B500257186 /* ContainSpec.mm in Sources */,
 				34FD463C1B99D25200257186 /* FooSuperclass.m in Sources */,
 				34FD46331B99D22D00257186 /* ObjectWithForwardingTarget.m in Sources */,
+				34D181A01BC7F0FF0087EC0D /* BlockMatcherSpec.mm in Sources */,
 				34FD464E1B99D2B000257186 /* MutableEqualSpec.mm in Sources */,
 				34FD463A1B99D24900257186 /* ExampleWithPublicRunDates.mm in Sources */,
 				34FD464D1B99D2B000257186 /* ExistSpec.mm in Sources */,
@@ -3648,6 +3676,7 @@
 				34D7C4A41BB9C69A00E8E523 /* CDRSpySpec.mm in Sources */,
 				34D7C4801BB9C60D00E8E523 /* SimpleKeyValueObserver.m in Sources */,
 				34D7C4881BB9C67100E8E523 /* WeakReferenceCompatibilitySpec.mm in Sources */,
+				34D1819F1BC7F0FD0087EC0D /* BlockMatcher_ARCSpecSpec.mm in Sources */,
 				34D7C4AB1BB9C6C400E8E523 /* CDRExampleSpec.mm in Sources */,
 				34D7C4761BB9B79D00E8E523 /* CDRJUnitXMLReporterSpec.mm in Sources */,
 				34D7C4771BB9B79D00E8E523 /* CDROTestReporterSpec.mm in Sources */,
@@ -3680,6 +3709,7 @@
 				34D7C47F1BB9C60A00E8E523 /* SimpleIncrementer.m in Sources */,
 				34D7C4B11BB9C6C400E8E523 /* SpecSpec.mm in Sources */,
 				34D7C47C1BB9C5FD00E8E523 /* ObjectWithProperty.m in Sources */,
+				34D1819E1BC7F0FD0087EC0D /* BlockMatcherSpec.mm in Sources */,
 				34D7C49B1BB9C67C00E8E523 /* RespondToSpec.mm in Sources */,
 				34D7C4791BB9B7AB00E8E523 /* ArgumentReleaser.m in Sources */,
 				34D7C49C1BB9C68100E8E523 /* BeEmptySpec.mm in Sources */,
@@ -3752,6 +3782,7 @@
 				AE1937781B1AC3DC008C8CD8 /* SimpleKeyValueObserver.m in Sources */,
 				AE1937631B1AC22D008C8CD8 /* CedarOrdinaryFakeSharedExamples.mm in Sources */,
 				AE1937771B1AC3DC008C8CD8 /* SimpleIncrementer.m in Sources */,
+				346F64701B82D3C900F64156 /* BlockMatcherSpec.mm in Sources */,
 				AE1937871B1AC94D008C8CD8 /* BeFalsySpec.mm in Sources */,
 				AE19375A1B1AC149008C8CD8 /* CDRDefaultReporterSpec.mm in Sources */,
 				AE1937741B1AC3DC008C8CD8 /* ObjectWithProperty.m in Sources */,
@@ -3782,6 +3813,7 @@
 				AE1937651B1AC22D008C8CD8 /* CDRSpecSpec.mm in Sources */,
 				AE1937921B1AC94D008C8CD8 /* ConformToSpec.mm in Sources */,
 				AE19378C1B1AC94D008C8CD8 /* BeLTESpec.mm in Sources */,
+				AE0BF0711B8E10D8000B0EE7 /* BlockMatcher_ARCSpecSpec.mm in Sources */,
 				AE1937A31B1ACC2E008C8CD8 /* GDataXMLNode.m in Sources */,
 				AE19379E1B1ACAFB008C8CD8 /* CDRJUnitXMLReporterSpec.mm in Sources */,
 				AE1937981B1AC94D008C8CD8 /* BeEmptySpec.mm in Sources */,
@@ -3936,6 +3968,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				AEEE21C411DC290400029872 /* SpecSpec2.m in Sources */,
+				346F646E1B82D3C900F64156 /* BlockMatcherSpec.mm in Sources */,
 				F7C8F3041BC63A000088069D /* ContainSubsetSpec.mm in Sources */,
 				AEEE21BF11DC290400029872 /* CDRExampleSpec.mm in Sources */,
 				AEEE21BE11DC290400029872 /* CDRExampleGroupSpec.mm in Sources */,
@@ -3986,6 +4019,7 @@
 				9D28051918E2321D00887CC4 /* ObjectWithValueEquality.m in Sources */,
 				E32861321604F287001FA77E /* FibonacciCalculator.m in Sources */,
 				96B5918F1630F5840068EA5E /* ObjCHeadersSpec.mm in Sources */,
+				AE0BF06F1B8E10D8000B0EE7 /* BlockMatcher_ARCSpecSpec.mm in Sources */,
 				AEE0665617315C20003CA143 /* CedarNiceFakeSharedExamples.mm in Sources */,
 				AEE0665917315DB8003CA143 /* CedarOrdinaryFakeSharedExamples.mm in Sources */,
 				AE9EAAD9178C789800CCF7DA /* CDRDefaultReporterSpec.mm in Sources */,
@@ -4081,6 +4115,7 @@
 				AE807892183C71950078C608 /* SimpleIncrementer.m in Sources */,
 				AEF7302013ECC4AE00786282 /* BeNilSpec.mm in Sources */,
 				AEF7302213ECC4AE00786282 /* BeSameInstanceAsSpec.mm in Sources */,
+				AE0BF0701B8E10D8000B0EE7 /* BlockMatcher_ARCSpecSpec.mm in Sources */,
 				AE0721E1187513870031CC42 /* ExistSpec.mm in Sources */,
 				AEF7302413ECC4AE00786282 /* BeTruthySpec.mm in Sources */,
 				AE53B67E17E7BCAA00D83D5E /* CDRClassFakeSpec.mm in Sources */,
@@ -4113,6 +4148,7 @@
 				AE06D88117AEEE230084D27C /* ObjectWithForwardingTarget.m in Sources */,
 				9672F0A71615C1C10012ED58 /* CDRSymbolicatorSpec.mm in Sources */,
 				9672F0AA1615C3F40012ED58 /* CDRSpecSpec.mm in Sources */,
+				346F646F1B82D3C900F64156 /* BlockMatcherSpec.mm in Sources */,
 				E32861331604F287001FA77E /* FibonacciCalculator.m in Sources */,
 				96B591911630F5B10068EA5E /* ObjCHeadersSpec.mm in Sources */,
 				AE80788F183C71950078C608 /* ArgumentReleaser.m in Sources */,

--- a/Cedar.xcodeproj/project.pbxproj
+++ b/Cedar.xcodeproj/project.pbxproj
@@ -1385,7 +1385,7 @@
 		34D4B5C118F3ADFF00FB2C3B /* UIKitContainSpec.mm */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.objcpp; path = UIKitContainSpec.mm; sourceTree = "<group>"; };
 		34D4B5C418F3B68900FB2C3B /* UIKitComparatorsContainer.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = UIKitComparatorsContainer.h; sourceTree = "<group>"; };
 		34D7C3CA1BB9747400E8E523 /* Cedar.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Cedar.framework; sourceTree = BUILT_PRODUCTS_DIR; };
-		34D7C4691BB9B71600E8E523 /* Cedar-tvOS SpecBundle.bundle */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = "Cedar-tvOS SpecBundle.bundle"; sourceTree = BUILT_PRODUCTS_DIR; };
+		34D7C4691BB9B71600E8E523 /* Cedar-tvOS SpecBundle.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = "Cedar-tvOS SpecBundle.xctest"; sourceTree = BUILT_PRODUCTS_DIR; };
 		34D7C4B71BB9CB5700E8E523 /* libxml2.tbd */ = {isa = PBXFileReference; lastKnownFileType = "sourcecode.text-based-dylib-definition"; name = libxml2.tbd; path = Platforms/AppleTVOS.platform/Developer/SDKs/AppleTVOS9.0.sdk/usr/lib/libxml2.tbd; sourceTree = DEVELOPER_DIR; };
 		34F3DF7B1A6ABA2E003041DA /* CDRNil.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = CDRNil.h; sourceTree = "<group>"; };
 		34F3DF7C1A6ABA2E003041DA /* CDRNil.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = CDRNil.m; sourceTree = "<group>"; };
@@ -2188,7 +2188,7 @@
 				346262781B99C1DB002CAEBD /* Cedar-watchOS Specs.app */,
 				346262841B99C1DC002CAEBD /* Cedar-watchOS Specs Extension.appex */,
 				34D7C3CA1BB9747400E8E523 /* Cedar.framework */,
-				34D7C4691BB9B71600E8E523 /* Cedar-tvOS SpecBundle.bundle */,
+				34D7C4691BB9B71600E8E523 /* Cedar-tvOS SpecBundle.xctest */,
 				34852D211BBE35FF0072D249 /* Cedar-watchOS HostApp.app */,
 			);
 			name = Products;
@@ -2959,7 +2959,7 @@
 			);
 			name = "Cedar-tvOS SpecBundle";
 			productName = "Cedar-tvOS-SpecBundle";
-			productReference = 34D7C4691BB9B71600E8E523 /* Cedar-tvOS SpecBundle.bundle */;
+			productReference = 34D7C4691BB9B71600E8E523 /* Cedar-tvOS SpecBundle.xctest */;
 			productType = "com.apple.product-type.bundle";
 		};
 		96A07EEE13F276640021974D /* Cedar-OSX FocusedSpecs */ = {
@@ -4629,6 +4629,7 @@
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SDKROOT = appletvos;
 				TVOS_DEPLOYMENT_TARGET = 9.0;
+				WRAPPER_EXTENSION = xctest;
 			};
 			name = Debug;
 		};
@@ -4659,6 +4660,7 @@
 				SDKROOT = appletvos;
 				TVOS_DEPLOYMENT_TARGET = 9.0;
 				VALIDATE_PRODUCT = YES;
+				WRAPPER_EXTENSION = xctest;
 			};
 			name = Release;
 		};

--- a/Cedar.xcodeproj/xcshareddata/xcschemes/Cedar-tvOS SpecBundle.xcscheme
+++ b/Cedar.xcodeproj/xcshareddata/xcschemes/Cedar-tvOS SpecBundle.xcscheme
@@ -15,7 +15,7 @@
             <BuildableReference
                BuildableIdentifier = "primary"
                BlueprintIdentifier = "34D7C4681BB9B71600E8E523"
-               BuildableName = "Cedar-tvOS SpecBundle.bundle"
+               BuildableName = "Cedar-tvOS SpecBundle.xctest"
                BlueprintName = "Cedar-tvOS SpecBundle"
                ReferencedContainer = "container:Cedar.xcodeproj">
             </BuildableReference>
@@ -33,7 +33,7 @@
             <BuildableReference
                BuildableIdentifier = "primary"
                BlueprintIdentifier = "34D7C4681BB9B71600E8E523"
-               BuildableName = "Cedar-tvOS SpecBundle.bundle"
+               BuildableName = "Cedar-tvOS SpecBundle.xctest"
                BlueprintName = "Cedar-tvOS SpecBundle"
                ReferencedContainer = "container:Cedar.xcodeproj">
             </BuildableReference>

--- a/Cedar.xcodeproj/xcshareddata/xcschemes/Cedar-tvOS.xcscheme
+++ b/Cedar.xcodeproj/xcshareddata/xcschemes/Cedar-tvOS.xcscheme
@@ -29,7 +29,7 @@
             <BuildableReference
                BuildableIdentifier = "primary"
                BlueprintIdentifier = "34D7C4681BB9B71600E8E523"
-               BuildableName = "Cedar-tvOS SpecBundle.bundle"
+               BuildableName = "Cedar-tvOS SpecBundle.xctest"
                BlueprintName = "Cedar-tvOS SpecBundle"
                ReferencedContainer = "container:Cedar.xcodeproj">
             </BuildableReference>
@@ -47,7 +47,7 @@
             <BuildableReference
                BuildableIdentifier = "primary"
                BlueprintIdentifier = "34D7C4681BB9B71600E8E523"
-               BuildableName = "Cedar-tvOS SpecBundle.bundle"
+               BuildableName = "Cedar-tvOS SpecBundle.xctest"
                BlueprintName = "Cedar-tvOS SpecBundle"
                ReferencedContainer = "container:Cedar.xcodeproj">
             </BuildableReference>

--- a/Source/Headers/Public/Matchers/Base/BlockMatcher.h
+++ b/Source/Headers/Public/Matchers/Base/BlockMatcher.h
@@ -1,0 +1,151 @@
+#import "Base.h"
+
+// The SDKs that ship with Xcode 7 define OBJC_BOOL_IS_BOOL or OBJC_BOOL_IS_CHAR depending
+// on the current platform. Here we enable backwards-compatibility
+#if defined(OBJC_BOOL_IS_BOOL)
+    #define CDR_OBJC_BOOL_IS_BOOL OBJC_BOOL_IS_BOOL
+#elif !defined(OBJC_BOOL_IS_CHAR) && (TARGET_OS_IPHONE && __LP64__)
+    #define CDR_OBJC_BOOL_IS_BOOL 1
+#endif
+
+#if __has_feature(objc_arc)
+#define CDR_RELEASE(X)
+#else
+#define CDR_RELEASE(X) if (X != nil) { [X release]; }
+#endif
+
+namespace Cedar { namespace Matchers {
+    typedef NSString *(^FailureMessageEndBlock)(void);
+
+#pragma mark - private interface
+    namespace Private {
+        template<typename T>
+        class BlockMatcher : public Base<> {
+        private:
+            BlockMatcher<T> & operator=(const BlockMatcher<T> &);
+
+        public:
+            BlockMatcher(bool (^const matchesBlock)(T subject), FailureMessageEndBlock failureMessageEndBlock);
+            BlockMatcher(const BlockMatcher<T> &obj);
+            ~BlockMatcher();
+
+            bool matches(const T &) const;
+
+        protected:
+            virtual NSString * failure_message_end() const;
+
+        private:
+            bool (^const matchesBlock_)(T);
+            const FailureMessageEndBlock failureMessageEndBlock_;
+        };
+
+        template<typename T>
+        BlockMatcher<T>::BlockMatcher(bool (^const matchesBlock)(T), FailureMessageEndBlock failureMessageEndBlock)
+        : matchesBlock_([matchesBlock copy]), failureMessageEndBlock_([failureMessageEndBlock copy]) {}
+
+        template<typename T>
+        BlockMatcher<T>::BlockMatcher(const BlockMatcher<T> &obj)
+        : matchesBlock_([obj.matchesBlock_ copy]), failureMessageEndBlock_([obj.failureMessageEndBlock_ copy]) {}
+
+        template<typename T>
+        BlockMatcher<T>::~BlockMatcher() {
+            CDR_RELEASE(matchesBlock_);
+            CDR_RELEASE(failureMessageEndBlock_);
+        }
+
+        template<typename T>
+        NSString *BlockMatcher<T>::failure_message_end() const {
+            return failureMessageEndBlock_ ? failureMessageEndBlock_() : @"";
+        }
+
+        template<typename T>
+        bool BlockMatcher<T>::matches(const T &subject) const {
+            return matchesBlock_(subject);
+        }
+
+
+        template<typename T>
+        struct BlockMatcherBuilder {
+            BlockMatcherBuilder(bool (^matchesBlock)(T subject));
+            BlockMatcherBuilder(const BlockMatcherBuilder<T> &obj);
+             ~BlockMatcherBuilder();
+
+            BlockMatcher<T> matcher() const; // Explicit builder function
+            operator BlockMatcher<T>() const; // Implicit builder function
+
+            BlockMatcherBuilder<T> & with_failure_message_end(NSString * const message);
+            BlockMatcherBuilder<T> & with_failure_message_end(FailureMessageEndBlock failureMessageEndBlock);
+
+        private:
+            bool (^const matchesBlock_)(T);
+            FailureMessageEndBlock failureMessageEndBlock_;
+        };
+
+        template<typename T>
+        BlockMatcherBuilder<T>::BlockMatcherBuilder(bool (^matchesBlock)(T))
+        : matchesBlock_([matchesBlock copy]), failureMessageEndBlock_([^{ return @"pass a test"; } copy]) {}
+
+        template<typename T>
+        BlockMatcherBuilder<T>::BlockMatcherBuilder(const BlockMatcherBuilder &obj)
+        : matchesBlock_([obj.matchesBlock_ copy]), failureMessageEndBlock_([obj.failureMessageEndBlock_ copy]) {}
+
+        template<typename T>
+        BlockMatcherBuilder<T>::~BlockMatcherBuilder() {
+            CDR_RELEASE(matchesBlock_);
+            CDR_RELEASE(failureMessageEndBlock_);
+        }
+
+        template<typename T>
+        BlockMatcher<T> BlockMatcherBuilder<T>::matcher() const {
+            return BlockMatcher<T>(matchesBlock_, failureMessageEndBlock_);
+        }
+
+        template <typename T>
+        BlockMatcherBuilder<T>::operator BlockMatcher<T>() const {
+            return matcher();
+        }
+
+        template<typename T>
+        BlockMatcherBuilder<T> & BlockMatcherBuilder<T>::with_failure_message_end(NSString * const message) {
+            return with_failure_message_end(^{ return message; });
+        }
+
+        template<typename T>
+        BlockMatcherBuilder<T> & BlockMatcherBuilder<T>::with_failure_message_end(FailureMessageEndBlock failureMessageEndBlock) {
+            CDR_RELEASE(failureMessageEndBlock_);
+            failureMessageEndBlock_ = [failureMessageEndBlock copy];
+            return *this;
+        }
+    }
+
+#pragma mark - public interface
+    template<typename T>
+    using CedarBlockMatcher = Cedar::Matchers::Private::BlockMatcher<T>;
+
+    template<typename T>
+    using CedarBlockMatcherBuilder = Cedar::Matchers::Private::BlockMatcherBuilder<T>;
+
+    template<typename T>
+    CedarBlockMatcherBuilder<T> expectationVerifier(bool (^matchesBlock)(T subject)) {
+        return CedarBlockMatcherBuilder<T>(matchesBlock);
+    }
+
+    template<typename T>
+    CedarBlockMatcher<T> matcherFor(NSString * const failureMessageEnd, bool (^matchesBlock)(T subject)) {
+        return expectationVerifier(matchesBlock).with_failure_message_end(failureMessageEnd);
+    }
+
+#if !CDR_OBJC_BOOL_IS_BOOL
+    template<typename T>
+    CedarBlockMatcherBuilder<T> expectationVerifier(BOOL (^matchesBlock)(T subject)) {
+        return CedarBlockMatcherBuilder<T>(^(T subject){ return !(matchesBlock(subject) == NO); });
+    }
+
+    template<typename T>
+    CedarBlockMatcher<T> matcherFor(NSString * const failureMessageEnd, BOOL (^matchesBlock)(T subject)) {
+        return expectationVerifier(matchesBlock).with_failure_message_end(failureMessageEnd);
+    }
+#endif
+}}
+
+#undef CDR_RELEASE

--- a/Source/Headers/Public/Matchers/CedarMatchers.h
+++ b/Source/Headers/Public/Matchers/CedarMatchers.h
@@ -13,6 +13,7 @@
 #import "RaiseException.h"
 #import "RespondTo.h"
 #import "ConformTo.h"
+#import "BlockMatcher.h"
 
 // Container
 #import "BeEmpty.h"

--- a/Spec/Matchers/Base/BlockMatcherSpec.mm
+++ b/Spec/Matchers/Base/BlockMatcherSpec.mm
@@ -1,0 +1,207 @@
+#import <Cedar/Cedar.h>
+#import "ExpectFailureWithMessage.h"
+
+using namespace Cedar::Matchers;
+
+SPEC_BEGIN(BlockMatcherSpec)
+
+describe(@"BlockMatcher", ^{
+
+    context(@"when the matcher is typed as 'id'", ^{
+        id expectedSubject = @"subj";
+
+        context(@"and the subject is typed as 'id'", ^{
+            __block id actualSubject;
+
+            context(@"when no failure message is provided", ^{
+                auto be_a_match = expectationVerifier(^(id subject){
+                    return [subject isEqual:expectedSubject];
+                }).matcher();
+
+                describe(@"positive match", ^{
+                    it(@"should pass", ^{
+                        actualSubject = @"subj";
+                        actualSubject should be_a_match;
+                    });
+
+                    it(@"should fail with the returned failure message", ^{
+                        actualSubject = @"other";
+                        expectFailureWithMessage(@"Expected <other> to pass a test", ^{
+                            actualSubject should be_a_match;
+                        });
+                    });
+                });
+
+                describe(@"negative match", ^{
+                    it(@"should pass", ^{
+                        actualSubject = @"other";
+                        actualSubject should_not be_a_match;
+                    });
+
+                    it(@"should fail with the returned failure message", ^{
+                        actualSubject = @"subj";
+                        expectFailureWithMessage(@"Expected <subj> to not pass a test", ^{
+                            actualSubject should_not be_a_match;
+                        });
+                    });
+                });
+            });
+
+            context(@"when a failure message string is provided", ^{
+                CedarBlockMatcher<id> be_a_match = expectationVerifier(^(id subject){
+                    return [subject isEqual:expectedSubject];
+                }).with_failure_message_end(@"be a match").matcher();
+
+                describe(@"positive match", ^{
+                    it(@"should pass", ^{
+                        actualSubject = @"subj";
+                        actualSubject should be_a_match;
+                    });
+
+                    it(@"should fail with the returned failure message", ^{
+                        actualSubject = @"other";
+                        expectFailureWithMessage(@"Expected <other> to be a match", ^{
+                            actualSubject should be_a_match;
+                        });
+                    });
+                });
+
+                describe(@"negative match", ^{
+                    it(@"should pass", ^{
+                        actualSubject = @"other";
+                        actualSubject should_not be_a_match;
+                    });
+
+                    it(@"should fail with the returned failure message", ^{
+                        actualSubject = @"subj";
+                        expectFailureWithMessage(@"Expected <subj> to not be a match", ^{
+                            actualSubject should_not be_a_match;
+                        });
+                    });
+                });
+            });
+
+            context(@"when a failure message block is provided", ^{
+                auto be_a_match = expectationVerifier(^(id subject){
+                    return [subject isEqual:expectedSubject];
+                }).with_failure_message_end(^{ return @"be a perfect match"; }).matcher();
+
+                describe(@"positive match", ^{
+                    it(@"should pass", ^{
+                        actualSubject = @"subj";
+                        actualSubject should be_a_match;
+                    });
+
+                    it(@"should fail with the returned failure message", ^{
+                        actualSubject = @"other";
+                        expectFailureWithMessage(@"Expected <other> to be a perfect match", ^{
+                            actualSubject should be_a_match;
+                        });
+                    });
+                });
+
+                describe(@"negative match", ^{
+                    it(@"should pass", ^{
+                        actualSubject = @"other";
+                        actualSubject should_not be_a_match;
+                    });
+
+                    it(@"should fail with the returned failure message", ^{
+                        actualSubject = @"subj";
+                        expectFailureWithMessage(@"Expected <subj> to not be a perfect match", ^{
+                            actualSubject should_not be_a_match;
+                        });
+                    });
+                });
+            });
+        });
+
+        context(@"and the subject is typed as an object subclass", ^{
+            auto be_a_match = expectationVerifier(^(id subject){
+                return [subject isEqual:expectedSubject];
+            }).matcher();
+            __block NSString *actualSubject;
+
+            it(@"should pass", ^{
+                actualSubject = @"subj";
+                actualSubject should be_a_match;
+            });
+        });
+    });
+
+    context(@"when the matcher is typed as an object subclass", ^{
+        NSString *expectedSubject = @"subj";
+        auto be_a_match = expectationVerifier(^(NSString *subject){
+            return [subject isEqual:expectedSubject];
+        }).matcher();
+
+        context(@"and the subject has the same type", ^{
+            it(@"should pass", ^{
+                NSString *actualSubject = @"subj";
+                actualSubject should be_a_match;
+            });
+        });
+
+        context(@"and the subject is a subclass of the matcher's type", ^{
+            it(@"should pass", ^{
+                NSMutableString *actualSubject = [@"subj" mutableCopy];
+                actualSubject should be_a_match;
+            });
+        });
+    });
+
+    context(@"when the subject is a primitive", ^{
+        NSInteger expectedSubject = 42;
+
+        auto be_a_match = expectationVerifier(^(NSInteger subject){
+            return subject == expectedSubject;
+        }).matcher();
+
+        describe(@"positive match", ^{
+            it(@"should pass", ^{
+                42 should be_a_match;
+            });
+
+            it(@"should fail with the returned failure message", ^{
+                expectFailureWithMessage(@"Expected <999> to pass a test", ^{
+                    999 should be_a_match;
+                });
+            });
+        });
+
+        describe(@"negative match", ^{
+            it(@"should pass", ^{
+                999 should_not be_a_match;
+            });
+
+            it(@"should fail with the returned failure message", ^{
+                expectFailureWithMessage(@"Expected <42> to not pass a test", ^{
+                    42 should_not be_a_match;
+                });
+            });
+        });
+    });
+
+    describe(@"builder shorthand", ^{
+        it(@"should allow building a matcher via implicit conversion", ^{
+            CedarBlockMatcher<id> pass = expectationVerifier(^(id subject){
+                return true;
+            });
+
+            @"hi" should pass;
+        });
+
+        it(@"should allow building a matcher including failure_message_end with a single function call", ^{
+            auto be_cute = matcherFor(@"be cute", ^(NSString *subject){
+                return [[subject lowercaseString] rangeOfString:@"kitten"].location != NSNotFound;
+            });
+
+            @"kittens" should be_cute;
+            expectFailureWithMessage(@"Expected <snakes> to be cute", ^{
+                @"snakes" should be_cute;
+            });
+        });
+    });
+});
+
+SPEC_END

--- a/Spec/Matchers/Base/BlockMatcher_ARCSpecSpec.mm
+++ b/Spec/Matchers/Base/BlockMatcher_ARCSpecSpec.mm
@@ -1,0 +1,20 @@
+#import <Cedar/Cedar.h>
+
+using namespace Cedar::Matchers;
+using namespace Cedar::Doubles;
+
+SPEC_BEGIN(BlockMatcher_ARCSpecSpec)
+
+describe(@"BlockMatcher", ^{
+    id expectedSubject = @"subj";
+
+    auto be_a_match = expectationVerifier(^(id subject){
+        return [subject isEqual:expectedSubject];
+    }).matcher();
+
+    it(@"should be usable under ARC", ^{
+        @"subj" should be_a_match;
+    });
+});
+
+SPEC_END


### PR DESCRIPTION
On my current project, there have been a couple instances recently where my tests were really calling for a nice domain-specific matcher, but I decided not to write one because I didn't want to have to deal with creating a new C++ type, remembering how the Base matcher works, etc., so I decided to see what I could do about providing a simpler mechanism for doing this.

I came up with this BlockMatcher interface which I am reasonably, although not entirely, happy with. Its usage looks like this:

```objective-c
// Defined in your spec, or in a test helper somewhere:
CedarBlockMatcher be_a_palindrome = matcher(^(NSString *subject) {
    subject = [subject lowercaseString];
    return [subject isEqual:[subject reversedString]]; // -reversedString defined elsewhere
}).with_failure_message_end(@"be a palindrome")();

it(@"should match palindromes", ^{
    @"Anna" should be_a_palindrome; // passes
    @"Tom" should be_a_palindrome; // fails with: Expected <Tom> to be a palindrome
});
```
Or if you need to parameterize the matcher:

```objective-c
CedarBlockMatcher be_below(UIView *referenceView) {
    return matcher(^BOOL(UIView *subject) {
        return CGRectGetMinY(subject.frame) >= CGRectGetMaxY(referenceView.frame);
    }).with_failure_message_end([NSString stringWithFormat:@"be below %@", referenceView])();
}

it(@"should match view positioning", ^{
    UIView *referenceView = [[UIView alloc] initWithFrame:CGRectMake(0, 0, 30, 30)];
    UIView *passingView = [[UIView alloc] initWithFrame:CGRectMake(0, 35, 30, 30)];
    UIView *failingView = [[UIView alloc] initWithFrame:CGRectMake(0, 20, 30, 30)];

    passingView should be_below(referenceView); // passes
    failingView should be_below(referenceView); // fails
});
```

Things I like about this interface:
* Defining a matcher can be as easy as providing a block that takes an `id` and returns `BOOL`!
* Blocks! allows for capturing ambient context in the matcher definition if it is declared inside of your spec file
* Fluent interface for optionally providing a specialized failure message

Things I'm not so sure about:
* Matchers built with this API are typed as `CedarBlockMatcher`, which would ideally be an implementation detail. AFAICT we don't really have a matcher supertype that would be appropriate to use for type erasure
* The fluent interface requires a `()` as the last step, to provide the freeze-dried `CedarBlockMatcher`. I couldn't think of a good way around this just now
* Perhaps there should be some generics involved, to allow for subjects with types other than `id`?
* Is this API extensible enough to allow for more failure message customizability in the future if we want?

Feedback please @tjarratt @idoru @akitchen :smile: 