### PR TITLE
Adjust XCTest integration such that xctool finds Cedar specs

### DIFF
--- a/Source/Headers/Project/XCTest/CDRXCTestSupport.h
+++ b/Source/Headers/Project/XCTest/CDRXCTestSupport.h
@@ -18,8 +18,8 @@
 
 // XCTestSuite
 
-- (id)defaultTestSuite;
-- (id)CDR_original_defaultTestSuite;
+- (id)allTests;
+- (id)CDR_original_allTests;
 - (id)initWithName:(NSString *)aName;
 
 // XCTestObservationCenter

--- a/Source/XCTest/CDRXCTestFunctions.m
+++ b/Source/XCTest/CDRXCTestFunctions.m
@@ -36,18 +36,16 @@ void CDRInjectIntoXCTestRunner() {
         static CDRXCTestObserver *xcTestObserver;
         xcTestObserver = [[CDRXCTestObserver alloc] init];
         [observationCenter addTestObserver:xcTestObserver];
-
-        return;
     }
 
     Class testSuiteMetaClass = object_getClass(testSuiteClass);
-    Method m = class_getClassMethod(testSuiteClass, @selector(defaultTestSuite));
+    Method m = class_getClassMethod(testSuiteClass, @selector(allTests));
 
-    class_addMethod(testSuiteMetaClass, @selector(CDR_original_defaultTestSuite), method_getImplementation(m), method_getTypeEncoding(m));
+    class_addMethod(testSuiteMetaClass, @selector(CDR_original_allTests), method_getImplementation(m), method_getTypeEncoding(m));
     IMP newImp = imp_implementationWithBlock(^id(id self){
-        id defaultSuite = [self CDR_original_defaultTestSuite];
+        id defaultSuite = [self CDR_original_allTests];
         [defaultSuite addTest:CDRCreateXCTestSuite()];
         return defaultSuite;
     });
-    class_replaceMethod(testSuiteMetaClass, @selector(defaultTestSuite), newImp, method_getTypeEncoding(m));
+    class_replaceMethod(testSuiteMetaClass, @selector(allTests), newImp, method_getTypeEncoding(m));
 }


### PR DESCRIPTION
I'm hoping to play with this a little more to get more confidence in this change, but this seems to be a simple way to get to `xctool` find and execute Cedar specs. It turns out that `xctool` calls `+[XCTestSuite allTests]` when gathering the available tests. This method isn't in the public interface, but is what `+[XCTestSuite defaultTestSuite]` delegates to for doing all its work.

CC folks involved in #308 and facebook/xctool#417 - please give this a try!
@parse @haskelash @adamhrz