### PR TITLE
Crash due to some specific classes during beforeEach hook

### DIFF
--- a/Source/CDRFunctions.m
+++ b/Source/CDRFunctions.m
@@ -1,6 +1,7 @@
 #import <Foundation/Foundation.h>
 #import <objc/runtime.h>
 #import "CDRSpec.h"
+#import "CDRHooks.h"
 #import "CDRExampleGroup.h"
 #import "CDRExampleReporter.h"
 #import "CDRDefaultReporter.h"
@@ -108,7 +109,8 @@ void CDRDefineSharedExampleGroups() {
 BOOL CDRClassHasClassMethod(Class class, SEL selector) {
     const char *className = class_getName(class);
     if (strcmp("UIAccessibilitySafeCategory__NSObject", className) &&
-        strcmp("SCRCException", className)) {
+        strcmp("SCRCException", className) &&
+        class_conformsToProtocol(class, @protocol(CDRHooks))) {
         return !!class_getClassMethod(class, selector);
     }
     return NO;

--- a/Source/Headers/Public/CDRHooks.h
+++ b/Source/Headers/Public/CDRHooks.h
@@ -1,5 +1,10 @@
 #import <Foundation/Foundation.h>
 
+/**
+ * CDRHooks
+ *
+ * Use this protocol when you want to register a class for global beforeEach and afterEach blocks.
+ */
 @protocol CDRHooks <NSObject>
 
 @optional

--- a/Spec/GlobalBeforeEachSpec.mm
+++ b/Spec/GlobalBeforeEachSpec.mm
@@ -11,7 +11,7 @@ static unsigned int globalValue__ = 0;
 
 using namespace Cedar::Matchers;
 
-@interface SomeClass : NSObject
+@interface SomeClass : NSObject <CDRHooks>
 @end
 
 @implementation SomeClass


### PR DESCRIPTION
For me the culprit class is `GAITrackerModel` but for others it can be another class.
The crash happens in the [`CDRClassHasClassMethod`](https://github.com/pivotal/cedar/blob/master/Source/CDRFunctions.m#L112) function.

The solution is probably to have only the defined classes that register the `CDRHooks` just like `specta` did in the issue [specta#149](https://github.com/specta/specta/pull/149).

Cheers