### PR TITLE
Correct the spelling of CocoaPods in README

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -30,7 +30,7 @@ describe(@"Example specs on NSString", ^{
 
 # Quick start
 
-* Add Cedar to your project via [Cocoapods](https://cocoapods.org/pods/Cedar) (`pod 'Cedar'`), [Carthage](https://github.com/Carthage/Carthage) (`github "pivotal/cedar"`), or [another method](https://github.com/pivotal/cedar/wiki/Installation#available-installation-methods)
+* Add Cedar to your project via [CocoaPods](https://cocoapods.org/pods/Cedar) (`pod 'Cedar'`), [Carthage](https://github.com/Carthage/Carthage) (`github "pivotal/cedar"`), or [another method](https://github.com/pivotal/cedar/wiki/Installation#available-installation-methods)
 * Install the Cedar Xcode file templates using the [Alcatraz package manager](http://alcatraz.io/) or by running this command in a terminal:
 ```
     $ curl -L https://raw.github.com/pivotal/cedar/master/install.sh | bash


### PR DESCRIPTION

This pull requests corrects the spelling of **CocoaPods** 🤓
https://github.com/CocoaPods/shared_resources/tree/master/media

<blockquote class="twitter-tweet" data-lang="en"><p lang="en" dir="ltr">One day I’ll make a bot that looks through the READMEs of all Pods, looks to see if it uses “Cocoapods” and PRs “CocoaPods” :D</p>&mdash; Ørta (@orta) <a href="https://twitter.com/orta/status/697374357975388160">February 10, 2016</a></blockquote>
<script async src="//platform.twitter.com/widgets.js" charset="utf-8"></script>
