### PR TITLE
Register CDRXCTestObserver at init time instead

### DIFF
--- a/Source/XCTest/CDRXCTestFunctions.m
+++ b/Source/XCTest/CDRXCTestFunctions.m
@@ -29,15 +29,6 @@ void CDRInjectIntoXCTestRunner() {
         [[NSException exceptionWithName:@"CedarNoTestFrameworkAvailable" reason:@"You must link against either the XCTest or SenTestingKit frameworks." userInfo:nil] raise];
     }
 
-    // if possible, use the new XCTestObservation protocol available in Xcode 7
-    Class observationCenterClass = NSClassFromString(@"XCTestObservationCenter");
-    if (observationCenterClass && [observationCenterClass respondsToSelector:@selector(sharedTestObservationCenter)]) {
-        id observationCenter = [observationCenterClass sharedTestObservationCenter];
-        static CDRXCTestObserver *xcTestObserver;
-        xcTestObserver = [[CDRXCTestObserver alloc] init];
-        [observationCenter addTestObserver:xcTestObserver];
-    }
-
     Class testSuiteMetaClass = object_getClass(testSuiteClass);
     Method m = class_getClassMethod(testSuiteClass, @selector(allTests));
 

--- a/Source/XCTest/CDRXCTestObserver.m
+++ b/Source/XCTest/CDRXCTestObserver.m
@@ -7,7 +7,15 @@
 @end
 
 @implementation CDRXCTestObserver
-
+- (instancetype)init {
+    if (self = [super init]) {
+        Class observationCenterClass = NSClassFromString(@"XCTestObservationCenter");
+        if (observationCenterClass && [observationCenterClass respondsToSelector:@selector(sharedTestObservationCenter)]) {
+            [[observationCenterClass sharedTestObservationCenter] addTestObserver:self];
+        }
+    }
+    return self;
+}
 - (void)testSuiteWillStart:(XCTestSuite *)testSuite {
     if (self.observedTestSuiteStart) {
         return;


### PR DESCRIPTION
- Fixes missing console output when running on Xcode 7.3
- Requires Test Bundles to specify CDRXCTestObserver for the
  NSPrincipalClass key in Info.plist
- See http://www.openradar.me/21428551