### PR TITLE
Updated XCTest swizzling for test bundle setup

### DIFF
--- a/Source/Headers/Project/XCTest/CDRXCTestSupport.h
+++ b/Source/Headers/Project/XCTest/CDRXCTestSupport.h
@@ -18,8 +18,8 @@
 
 // XCTestSuite
 
-- (id)allTests;
-- (id)CDR_original_allTests;
++ (id)testSuiteForTestConfiguration:(id)testConfiguration;
++ (id)CDR_original_testSuiteForTestConfiguration:(id)testConfiguration;
 - (id)initWithName:(NSString *)aName;
 
 // XCTestObservationCenter

--- a/Source/Headers/Project/XCTest/CDRXCTestSupport.h
+++ b/Source/Headers/Project/XCTest/CDRXCTestSupport.h
@@ -18,8 +18,10 @@
 
 // XCTestSuite
 
++ (id)allTests;
 + (id)testSuiteForTestConfiguration:(id)testConfiguration;
 + (id)CDR_original_testSuiteForTestConfiguration:(id)testConfiguration;
++ (id)CDR_original_allTests;
 - (id)initWithName:(NSString *)aName;
 
 // XCTestObservationCenter


### PR DESCRIPTION
- Move Cedar XCTest set up to +testSuiteForTestConfiguration: swizzle
- Removes addition of CDRXCTestObserver for now since it creates an
  issue with Xcode