### PR TITLE
Defer test observation center setup to fix Xcode 7.3 regression

### DIFF
--- a/Spec/SpecBundle/Support/TestObservationHelper.m
+++ b/Spec/SpecBundle/Support/TestObservationHelper.m
@@ -16,7 +16,10 @@ static NSMutableArray *_knownTestSuites;
     if (observationCenterClass && [observationCenterClass respondsToSelector:@selector(sharedTestObservationCenter)]) {
         _knownTestSuites = [NSMutableArray array];
 
-        [[observationCenterClass sharedTestObservationCenter] addTestObserver:(id)[TestObservationHelper new]];
+        // See comment in CDRXCTestFunctions.m for context on the dispatch_async
+        dispatch_async(dispatch_get_main_queue(), ^{
+            [[observationCenterClass sharedTestObservationCenter] addTestObserver:(id)[TestObservationHelper new]];
+        });
     }
 }
 


### PR DESCRIPTION
This is yet another fix to the test output issue raised by @cbguder 

While not as techically clean as #379 it does appear to fix it reliably.