### PR TITLE
New attempt at fixing test output under Xcode 7.3 while not breaking …

### DIFF
--- a/Source/Headers/Project/XCTest/CDRXCTestSupport.h
+++ b/Source/Headers/Project/XCTest/CDRXCTestSupport.h
@@ -22,8 +22,12 @@
 - (id)CDR_original_allTests;
 - (id)initWithName:(NSString *)aName;
 
-// XCTestObservationCenter
+@end
+
+@interface XCTestObservationCenter: NSObject
 + (instancetype)sharedTestObservationCenter;
 - (void)addTestObserver:(id<XCTestObservation>)observer;
-
+- (void)_addLegacyTestObserver:(id)observer;
+- (void)CDR_original_addTestObserver:(id<XCTestObservation>)observer;
+- (void)CDR_original__addLegacyTestObserver:(id)observer;
 @end

--- a/Spec/SpecBundle/SpecBundle-Info.plist
+++ b/Spec/SpecBundle/SpecBundle-Info.plist
@@ -20,5 +20,7 @@
 	<string>????</string>
 	<key>CFBundleVersion</key>
 	<string>1</string>
+	<key>NSPrincipalClass</key>
+	<string>TestObservationHelper</string>
 </dict>
 </plist>

--- a/Spec/SpecBundle/Support/TestObservationHelper.m
+++ b/Spec/SpecBundle/Support/TestObservationHelper.m
@@ -7,20 +7,21 @@
 
 @interface TestObservationHelper () <XCTestObservation> @end
 
+// This class is loaded as the NSPrincipalClass of test bundles that require it, at which point
+// it registers itself as a test observer.
 @implementation TestObservationHelper
 
 static NSMutableArray *_knownTestSuites;
 
-+ (void)load {
-    Class observationCenterClass = NSClassFromString(@"XCTestObservationCenter");
-    if (observationCenterClass && [observationCenterClass respondsToSelector:@selector(sharedTestObservationCenter)]) {
-        _knownTestSuites = [NSMutableArray array];
-
-        // See comment in CDRXCTestFunctions.m for context on the dispatch_async
-        dispatch_async(dispatch_get_main_queue(), ^{
-            [[observationCenterClass sharedTestObservationCenter] addTestObserver:(id)[TestObservationHelper new]];
-        });
+- (instancetype)init {
+    if (self = [super init]) {
+        Class observationCenterClass = NSClassFromString(@"XCTestObservationCenter");
+        if (observationCenterClass && [observationCenterClass respondsToSelector:@selector(sharedTestObservationCenter)]) {
+            _knownTestSuites = [NSMutableArray array];
+            [[observationCenterClass sharedTestObservationCenter] addTestObserver:self];
+        }
     }
+    return self;
 }
 
 + (NSArray *)knownTestSuites {


### PR DESCRIPTION
…xctool

- The dispatch_async approach causes Cedar to not be hooked into XCTest
  in time for the xctool runner to pick it up.
- Instead, we are now swizzling -[XCTestObservationCenter addTestObserver:]
  and -_addLegacyTestObserver: and using them as an earlier hook to register
  Cedar's test observer with the test observation center.

Some extra context around this can be found at:
https://github.com/pivotal/cedar/issues/383