### PR TITLE
Raise errors when dsl is misused

### DIFF
--- a/Cedar.xcodeproj/project.pbxproj
+++ b/Cedar.xcodeproj/project.pbxproj
@@ -1133,6 +1133,13 @@
 		E32861331604F287001FA77E /* FibonacciCalculator.m in Sources */ = {isa = PBXBuildFile; fileRef = E32861311604F287001FA77E /* FibonacciCalculator.m */; };
 		E4BCFDD21817FA110083ED98 /* ObjectWithProperty.m in Sources */ = {isa = PBXBuildFile; fileRef = E4BCFDD11817FA110083ED98 /* ObjectWithProperty.m */; };
 		E4BCFDD31817FA110083ED98 /* ObjectWithProperty.m in Sources */ = {isa = PBXBuildFile; fileRef = E4BCFDD11817FA110083ED98 /* ObjectWithProperty.m */; };
+		F71C2F341D3DAD71003B37DC /* CedarTestSpecBuilder.m in Sources */ = {isa = PBXBuildFile; fileRef = F71C2F331D3DAD71003B37DC /* CedarTestSpecBuilder.m */; };
+		F71C2F361D3DAD71003B37DC /* CedarTestSpecBuilder.m in Sources */ = {isa = PBXBuildFile; fileRef = F71C2F331D3DAD71003B37DC /* CedarTestSpecBuilder.m */; };
+		F71C2F371D3DAD71003B37DC /* CedarTestSpecBuilder.m in Sources */ = {isa = PBXBuildFile; fileRef = F71C2F331D3DAD71003B37DC /* CedarTestSpecBuilder.m */; };
+		F71C2F381D3DAD71003B37DC /* CedarTestSpecBuilder.m in Sources */ = {isa = PBXBuildFile; fileRef = F71C2F331D3DAD71003B37DC /* CedarTestSpecBuilder.m */; };
+		F71C2F391D3DADD0003B37DC /* CedarTestSpecBuilder.m in Sources */ = {isa = PBXBuildFile; fileRef = F71C2F331D3DAD71003B37DC /* CedarTestSpecBuilder.m */; };
+		F71C2F3A1D3DADD1003B37DC /* CedarTestSpecBuilder.m in Sources */ = {isa = PBXBuildFile; fileRef = F71C2F331D3DAD71003B37DC /* CedarTestSpecBuilder.m */; };
+		F71C2F3B1D3DADD1003B37DC /* CedarTestSpecBuilder.m in Sources */ = {isa = PBXBuildFile; fileRef = F71C2F331D3DAD71003B37DC /* CedarTestSpecBuilder.m */; };
 		F78FDA161B43AA8C0054C768 /* CedarNiceFakeSharedExamples.mm in Sources */ = {isa = PBXBuildFile; fileRef = AEE0665517315C20003CA143 /* CedarNiceFakeSharedExamples.mm */; };
 		F78FDA181B43AA8F0054C768 /* CedarOrdinaryFakeSharedExamples.mm in Sources */ = {isa = PBXBuildFile; fileRef = AEE0665817315DB8003CA143 /* CedarOrdinaryFakeSharedExamples.mm */; };
 		F78FDA1A1B43AA930054C768 /* HaveReceivedSpec.mm in Sources */ = {isa = PBXBuildFile; fileRef = 6639A77A14C509FE00B564B7 /* HaveReceivedSpec.mm */; };
@@ -1145,6 +1152,34 @@
 		F7C8F3071BC63A000088069D /* ContainSubsetSpec.mm in Sources */ = {isa = PBXBuildFile; fileRef = F7C8F3031BC63A000088069D /* ContainSubsetSpec.mm */; };
 		F7C8F30B1BC63A000088069D /* ContainSubsetSpec.mm in Sources */ = {isa = PBXBuildFile; fileRef = F7C8F3031BC63A000088069D /* ContainSubsetSpec.mm */; };
 		F7C8F30C1BC63A000088069D /* ContainSubsetSpec.mm in Sources */ = {isa = PBXBuildFile; fileRef = F7C8F3031BC63A000088069D /* ContainSubsetSpec.mm */; };
+		F7C9BBED1D3E83E500B694C0 /* CDRSpecRunSpec.mm in Sources */ = {isa = PBXBuildFile; fileRef = F7C9BBEC1D3E838800B694C0 /* CDRSpecRunSpec.mm */; };
+		F7C9BBEE1D3E83EB00B694C0 /* CDRSpecRunSpec.mm in Sources */ = {isa = PBXBuildFile; fileRef = F7C9BBEC1D3E838800B694C0 /* CDRSpecRunSpec.mm */; };
+		F7C9BBEF1D3E83EB00B694C0 /* CDRSpecRunSpec.mm in Sources */ = {isa = PBXBuildFile; fileRef = F7C9BBEC1D3E838800B694C0 /* CDRSpecRunSpec.mm */; };
+		F7C9BBF01D3E83F100B694C0 /* CDRSpecRunSpec.mm in Sources */ = {isa = PBXBuildFile; fileRef = F7C9BBEC1D3E838800B694C0 /* CDRSpecRunSpec.mm */; };
+		F7C9BBF11D3E83F200B694C0 /* CDRSpecRunSpec.mm in Sources */ = {isa = PBXBuildFile; fileRef = F7C9BBEC1D3E838800B694C0 /* CDRSpecRunSpec.mm */; };
+		F7C9BBF21D3E83F200B694C0 /* CDRSpecRunSpec.mm in Sources */ = {isa = PBXBuildFile; fileRef = F7C9BBEC1D3E838800B694C0 /* CDRSpecRunSpec.mm */; };
+		F7C9BBF61D3E85FF00B694C0 /* CDRStateTracker.m in Sources */ = {isa = PBXBuildFile; fileRef = F7C9BBF51D3E85A100B694C0 /* CDRStateTracker.m */; };
+		F7C9BBF71D3E860000B694C0 /* CDRStateTracker.m in Sources */ = {isa = PBXBuildFile; fileRef = F7C9BBF51D3E85A100B694C0 /* CDRStateTracker.m */; };
+		F7C9BBF81D3E860100B694C0 /* CDRStateTracker.m in Sources */ = {isa = PBXBuildFile; fileRef = F7C9BBF51D3E85A100B694C0 /* CDRStateTracker.m */; };
+		F7C9BBF91D3E860100B694C0 /* CDRStateTracker.m in Sources */ = {isa = PBXBuildFile; fileRef = F7C9BBF51D3E85A100B694C0 /* CDRStateTracker.m */; };
+		F7C9BBFA1D3E860200B694C0 /* CDRStateTracker.m in Sources */ = {isa = PBXBuildFile; fileRef = F7C9BBF51D3E85A100B694C0 /* CDRStateTracker.m */; };
+		F7C9BC011D45E16200B694C0 /* CDRRunState.h in Headers */ = {isa = PBXBuildFile; fileRef = F7C9BBFF1D45E16200B694C0 /* CDRRunState.h */; };
+		F7C9BC021D45E16200B694C0 /* CDRRunState.m in Sources */ = {isa = PBXBuildFile; fileRef = F7C9BC001D45E16200B694C0 /* CDRRunState.m */; };
+		F7C9BC031D45E19A00B694C0 /* CDRRunState.m in Sources */ = {isa = PBXBuildFile; fileRef = F7C9BC001D45E16200B694C0 /* CDRRunState.m */; };
+		F7C9BC041D45E19B00B694C0 /* CDRRunState.m in Sources */ = {isa = PBXBuildFile; fileRef = F7C9BC001D45E16200B694C0 /* CDRRunState.m */; };
+		F7C9BC051D45E19B00B694C0 /* CDRRunState.m in Sources */ = {isa = PBXBuildFile; fileRef = F7C9BC001D45E16200B694C0 /* CDRRunState.m */; };
+		F7C9BC061D45E19C00B694C0 /* CDRRunState.m in Sources */ = {isa = PBXBuildFile; fileRef = F7C9BC001D45E16200B694C0 /* CDRRunState.m */; };
+		F7C9BC071D45E4E000B694C0 /* CDRRunState.h in Headers */ = {isa = PBXBuildFile; fileRef = F7C9BBFF1D45E16200B694C0 /* CDRRunState.h */; };
+		F7C9BC081D45E4E100B694C0 /* CDRRunState.h in Headers */ = {isa = PBXBuildFile; fileRef = F7C9BBFF1D45E16200B694C0 /* CDRRunState.h */; };
+		F7C9BC091D45E4E100B694C0 /* CDRRunState.h in Headers */ = {isa = PBXBuildFile; fileRef = F7C9BBFF1D45E16200B694C0 /* CDRRunState.h */; };
+		F7C9BC0A1D45E4E400B694C0 /* CDRStateTracker.h in Headers */ = {isa = PBXBuildFile; fileRef = F7C9BBF41D3E85A100B694C0 /* CDRStateTracker.h */; };
+		F7C9BC0B1D45E4E500B694C0 /* CDRStateTracker.h in Headers */ = {isa = PBXBuildFile; fileRef = F7C9BBF41D3E85A100B694C0 /* CDRStateTracker.h */; };
+		F7C9BC0C1D45E4E500B694C0 /* CDRStateTracker.h in Headers */ = {isa = PBXBuildFile; fileRef = F7C9BBF41D3E85A100B694C0 /* CDRStateTracker.h */; };
+		F7C9BC0D1D45E4E600B694C0 /* CDRStateTracker.h in Headers */ = {isa = PBXBuildFile; fileRef = F7C9BBF41D3E85A100B694C0 /* CDRStateTracker.h */; };
+		F7C9BC0E1D45E4EC00B694C0 /* CDRStateTracking.h in Headers */ = {isa = PBXBuildFile; fileRef = F7C9BBF31D3E851100B694C0 /* CDRStateTracking.h */; };
+		F7C9BC0F1D45E4EC00B694C0 /* CDRStateTracking.h in Headers */ = {isa = PBXBuildFile; fileRef = F7C9BBF31D3E851100B694C0 /* CDRStateTracking.h */; };
+		F7C9BC101D45E4ED00B694C0 /* CDRStateTracking.h in Headers */ = {isa = PBXBuildFile; fileRef = F7C9BBF31D3E851100B694C0 /* CDRStateTracking.h */; };
+		F7C9BC111D45E4ED00B694C0 /* CDRStateTracking.h in Headers */ = {isa = PBXBuildFile; fileRef = F7C9BBF31D3E851100B694C0 /* CDRStateTracking.h */; };
 		F7F4099B1B2E3C8B001EFA14 /* CDRXCTestObserver.m in Sources */ = {isa = PBXBuildFile; fileRef = F7F409971B2E3C8B001EFA14 /* CDRXCTestObserver.m */; };
 		F7F4099C1B2E3C8B001EFA14 /* CDRXCTestObserver.m in Sources */ = {isa = PBXBuildFile; fileRef = F7F409971B2E3C8B001EFA14 /* CDRXCTestObserver.m */; };
 		F7F4099D1B2E3C8B001EFA14 /* CDRXCTestObserver.m in Sources */ = {isa = PBXBuildFile; fileRef = F7F409971B2E3C8B001EFA14 /* CDRXCTestObserver.m */; };
@@ -1671,7 +1706,15 @@
 		E32861311604F287001FA77E /* FibonacciCalculator.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = FibonacciCalculator.m; sourceTree = "<group>"; };
 		E4BCFDD01817FA110083ED98 /* ObjectWithProperty.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = ObjectWithProperty.h; sourceTree = "<group>"; };
 		E4BCFDD11817FA110083ED98 /* ObjectWithProperty.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = ObjectWithProperty.m; sourceTree = "<group>"; };
+		F71C2F321D3DAD71003B37DC /* CedarTestSpecBuilder.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = CedarTestSpecBuilder.h; sourceTree = "<group>"; };
+		F71C2F331D3DAD71003B37DC /* CedarTestSpecBuilder.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = CedarTestSpecBuilder.m; sourceTree = "<group>"; };
 		F7C8F3031BC63A000088069D /* ContainSubsetSpec.mm */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.objcpp; path = ContainSubsetSpec.mm; sourceTree = "<group>"; };
+		F7C9BBEC1D3E838800B694C0 /* CDRSpecRunSpec.mm */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.objcpp; path = CDRSpecRunSpec.mm; sourceTree = "<group>"; };
+		F7C9BBF31D3E851100B694C0 /* CDRStateTracking.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = CDRStateTracking.h; path = ../../CDRStateTracking.h; sourceTree = "<group>"; };
+		F7C9BBF41D3E85A100B694C0 /* CDRStateTracker.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = CDRStateTracker.h; path = ../../CDRStateTracker.h; sourceTree = "<group>"; };
+		F7C9BBF51D3E85A100B694C0 /* CDRStateTracker.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = CDRStateTracker.m; sourceTree = "<group>"; };
+		F7C9BBFF1D45E16200B694C0 /* CDRRunState.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = CDRRunState.h; sourceTree = "<group>"; };
+		F7C9BC001D45E16200B694C0 /* CDRRunState.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = CDRRunState.m; sourceTree = "<group>"; };
 		F7F409971B2E3C8B001EFA14 /* CDRXCTestObserver.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = CDRXCTestObserver.m; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
@@ -1865,7 +1908,10 @@
 				34F3DF7B1A6ABA2E003041DA /* CDRNil.h */,
 				34777EB61B99451200A69FCF /* CDRPrivateFunctions.h */,
 				AE55BF1D19A7CF83005948E6 /* CDRRuntimeUtilities.h */,
+				F7C9BBFF1D45E16200B694C0 /* CDRRunState.h */,
+				F7C9BBF41D3E85A100B694C0 /* CDRStateTracker.h */,
 				3492DA9D1BA6F9E70032B35A /* CDRSpecRun.h */,
+				F7C9BBF31D3E851100B694C0 /* CDRStateTracking.h */,
 				969B6F95160F1FEC00C7C792 /* CDRSymbolicator.h */,
 				34681C2D18FE4611009D38AC /* CDRTypeUtilities.h */,
 			);
@@ -2276,16 +2322,18 @@
 				AEEE1FC611DC27B800029872 /* CDRExampleBase.m */,
 				AEEE1FC711DC27B800029872 /* CDRExampleGroup.m */,
 				AEEE1FC811DC27B800029872 /* CDRFunctions.m */,
-				96EA1CA7142C6425001A78E0 /* CDRTestBundleRunner.m */,
+				34F3DF7C1A6ABA2E003041DA /* CDRNil.m */,
 				AE55BF1A19A7CF58005948E6 /* CDRRuntimeUtilities.m */,
 				AEFD17B111DD1E7200F4448A /* CDRSharedExampleGroupPool.m */,
 				AEEE1FC911DC27B800029872 /* CDRSpec.m */,
 				AEEF360619DE21DB00794484 /* CDRSpecFailure.m */,
 				AEEE1FE611DC27B800029872 /* CDRSpecHelper.m */,
-				969B6F82160C61E000C7C792 /* CDRSymbolicator.m */,
-				34681C2B18FE451E009D38AC /* CDRTypeUtilities.m */,
-				34F3DF7C1A6ABA2E003041DA /* CDRNil.m */,
 				3492DA9E1BA6F9E70032B35A /* CDRSpecRun.m */,
+				F7C9BC001D45E16200B694C0 /* CDRRunState.m */,
+				F7C9BBF51D3E85A100B694C0 /* CDRStateTracker.m */,
+				969B6F82160C61E000C7C792 /* CDRSymbolicator.m */,
+				96EA1CA7142C6425001A78E0 /* CDRTestBundleRunner.m */,
+				34681C2B18FE451E009D38AC /* CDRTypeUtilities.m */,
 			);
 			path = Source;
 			sourceTree = "<group>";
@@ -2320,6 +2368,22 @@
 		AEEE1FE711DC27B800029872 /* Spec */ = {
 			isa = PBXGroup;
 			children = (
+				1F45A3E2180E4A1C003C1E36 /* SpecBundleApplicationTestsWithXCTest.m */,
+				AEEE1FF211DC27B800029872 /* SpecSpec2.m */,
+				AEEE1FE811DC27B800029872 /* CDRExampleGroupSpec.mm */,
+				AEEE1FE911DC27B800029872 /* CDRExampleSpec.mm */,
+				AEEE1FF011DC27B800029872 /* CDRHooksSpec.mm */,
+				34F3DF811A6ABB21003041DA /* CDRNilSpec.mm */,
+				96EA1CB9142C6560001A78E0 /* CDRSpecFailureSpec.mm */,
+				F7C9BBEC1D3E838800B694C0 /* CDRSpecRunSpec.mm */,
+				9672F0A81615C3F40012ED58 /* CDRSpecSpec.mm */,
+				96C95B7D161339160018606B /* CDRSymbolicatorSpec.mm */,
+				34681C2F18FE4B68009D38AC /* CDRTypeUtilitiesSpec.mm */,
+				AEEE1FEF11DC27B800029872 /* main.mm */,
+				96B5918E1630F5840068EA5E /* ObjCHeadersSpec.mm */,
+				96D34483144A845100352C4A /* SpecBundleApplicationTests.mm */,
+				AEEE1FF111DC27B800029872 /* SpecSpec.mm */,
+				346D1A981BBB389A00BECD4B /* SpecBundle-Info.plist */,
 				66F00B5014C4D92500146D88 /* Doubles */,
 				96A07F0D13F27ED70021974D /* Focused */,
 				AEEE1FEB11DC27B800029872 /* iOS */,
@@ -2327,25 +2391,10 @@
 				1FE15C25186919F400207F0C /* Reporters */,
 				AEEF360C19DF248F00794484 /* Resources */,
 				346D1AA01BBB445B00BECD4B /* SpecBundle */,
-				346D1A981BBB389A00BECD4B /* SpecBundle-Info.plist */,
-				1F45A3E2180E4A1C003C1E36 /* SpecBundleApplicationTestsWithXCTest.m */,
-				96D34483144A845100352C4A /* SpecBundleApplicationTests.mm */,
-				34DB67471C2B4CBA00206663 /* Swift */,
 				E328612E1604F254001FA77E /* Support */,
+				34DB67471C2B4CBA00206663 /* Swift */,
 				346262791B99C1DB002CAEBD /* watchOS */,
 				AE34723F19C2257A005CA6F1 /* XCTest */,
-				AEEE1FE811DC27B800029872 /* CDRExampleGroupSpec.mm */,
-				AEEE1FE911DC27B800029872 /* CDRExampleSpec.mm */,
-				34F3DF811A6ABB21003041DA /* CDRNilSpec.mm */,
-				96EA1CB9142C6560001A78E0 /* CDRSpecFailureSpec.mm */,
-				9672F0A81615C3F40012ED58 /* CDRSpecSpec.mm */,
-				96C95B7D161339160018606B /* CDRSymbolicatorSpec.mm */,
-				34681C2F18FE4B68009D38AC /* CDRTypeUtilitiesSpec.mm */,
-				AEEE1FF011DC27B800029872 /* CDRHooksSpec.mm */,
-				AEEE1FEF11DC27B800029872 /* main.mm */,
-				96B5918E1630F5840068EA5E /* ObjCHeadersSpec.mm */,
-				AEEE1FF111DC27B800029872 /* SpecSpec.mm */,
-				AEEE1FF211DC27B800029872 /* SpecSpec2.m */,
 			);
 			path = Spec;
 			sourceTree = "<group>";
@@ -2484,31 +2533,33 @@
 				AE71E7CB175E958F002A54D5 /* ARCViewController.m */,
 				AE807887183C71950078C608 /* ArgumentReleaser.h */,
 				AE807888183C71950078C608 /* ArgumentReleaser.m */,
+				AE8F1D901850F6C00059E840 /* CedarObservedObject.h */,
+				F71C2F321D3DAD71003B37DC /* CedarTestSpecBuilder.h */,
+				F71C2F331D3DAD71003B37DC /* CedarTestSpecBuilder.m */,
+				343FAFE8190FDAEC0085AFEC /* DeallocNotifier.h */,
+				343FAFE9190FDAEC0085AFEC /* DeallocNotifier.m */,
+				4523F16026FC3298AB3B00BE /* ExampleWithPublicRunDates.h */,
+				4523F1D0182DEAB34B1E7C83 /* ExampleWithPublicRunDates.mm */,
 				E32861301604F287001FA77E /* FibonacciCalculator.h */,
 				E32861311604F287001FA77E /* FibonacciCalculator.m */,
+				AED10EBA18F46C0E00950904 /* FooSuperclass.h */,
+				AED10EBB18F46C0E00950904 /* FooSuperclass.m */,
+				4523FFB9BD607306C7ED94A3 /* GData */,
+				AE3E8F35184FEEE000633740 /* ObjectWithCollections.h */,
+				AE3E8F36184FEEE000633740 /* ObjectWithCollections.m */,
 				AE06D87E17AEEE230084D27C /* ObjectWithForwardingTarget.h */,
 				AE06D87F17AEEE230084D27C /* ObjectWithForwardingTarget.m */,
 				E4BCFDD01817FA110083ED98 /* ObjectWithProperty.h */,
 				E4BCFDD11817FA110083ED98 /* ObjectWithProperty.m */,
-				AE5218D1175979CA00A656BC /* ObjectWithWeakDelegate.h */,
-				AE5218D2175979CA00A656BC /* ObjectWithWeakDelegate.m */,
-				AE3E8F35184FEEE000633740 /* ObjectWithCollections.h */,
-				AE3E8F36184FEEE000633740 /* ObjectWithCollections.m */,
-				AE807889183C71950078C608 /* SimpleIncrementer.h */,
-				AE80788A183C71950078C608 /* SimpleIncrementer.m */,
-				AEF52C26187F236D00C8D2D8 /* SimpleMultiplier.h */,
-				AE80788B183C71950078C608 /* SimpleKeyValueObserver.h */,
-				AE80788C183C71950078C608 /* SimpleKeyValueObserver.m */,
-				AE8F1D901850F6C00059E840 /* CedarObservedObject.h */,
-				4523FFB9BD607306C7ED94A3 /* GData */,
-				4523F1D0182DEAB34B1E7C83 /* ExampleWithPublicRunDates.mm */,
-				4523F16026FC3298AB3B00BE /* ExampleWithPublicRunDates.h */,
 				9D28051718E2321D00887CC4 /* ObjectWithValueEquality.h */,
 				9D28051818E2321D00887CC4 /* ObjectWithValueEquality.m */,
-				AED10EBA18F46C0E00950904 /* FooSuperclass.h */,
-				AED10EBB18F46C0E00950904 /* FooSuperclass.m */,
-				343FAFE8190FDAEC0085AFEC /* DeallocNotifier.h */,
-				343FAFE9190FDAEC0085AFEC /* DeallocNotifier.m */,
+				AE5218D1175979CA00A656BC /* ObjectWithWeakDelegate.h */,
+				AE5218D2175979CA00A656BC /* ObjectWithWeakDelegate.m */,
+				AE807889183C71950078C608 /* SimpleIncrementer.h */,
+				AE80788A183C71950078C608 /* SimpleIncrementer.m */,
+				AE80788B183C71950078C608 /* SimpleKeyValueObserver.h */,
+				AE80788C183C71950078C608 /* SimpleKeyValueObserver.m */,
+				AEF52C26187F236D00C8D2D8 /* SimpleMultiplier.h */,
 				34AF814C1C53339300DB5249 /* TestReporter.h */,
 				34AF814D1C53339300DB5249 /* TestReporter.m */,
 			);
@@ -2550,11 +2601,13 @@
 				346262201B995491002CAEBD /* ComparatorsContainer.h in Headers */,
 				346261F51B995426002CAEBD /* CDRXCTestCase.h in Headers */,
 				3462623E1B9954C1002CAEBD /* CDRSharedExampleGroupPool.h in Headers */,
+				F7C9BC081D45E4E100B694C0 /* CDRRunState.h in Headers */,
 				346261F31B995422002CAEBD /* CDRSymbolicator.h in Headers */,
 				346261E71B995422002CAEBD /* CDRSpyInfo.h in Headers */,
 				346262081B99544D002CAEBD /* InvocationMatcher.h in Headers */,
 				3462620C1B99546C002CAEBD /* BeFalsy.h in Headers */,
 				346262191B99546C002CAEBD /* RespondTo.h in Headers */,
+				F7C9BC0B1D45E4E500B694C0 /* CDRStateTracker.h in Headers */,
 				346261E81B995422002CAEBD /* CedarDoubleImpl.h in Headers */,
 				346262421B9954C1002CAEBD /* CDRVersion.h in Headers */,
 				34D1819C1BC7F0E60087EC0D /* BlockMatcher.h in Headers */,
@@ -2573,6 +2626,7 @@
 				346261FD1B995445002CAEBD /* AnyArgument.h in Headers */,
 				346262211B995491002CAEBD /* CompareEqual.h in Headers */,
 				346262111B99546C002CAEBD /* BeLTE.h in Headers */,
+				F7C9BC0F1D45E4EC00B694C0 /* CDRStateTracking.h in Headers */,
 				346262021B99544D002CAEBD /* CDRSpy.h in Headers */,
 				346261F11B995422002CAEBD /* CDRPrivateFunctions.h in Headers */,
 				3462622D1B9954A8002CAEBD /* CedarComparators.h in Headers */,
@@ -2626,6 +2680,7 @@
 				34D7C4321BB9B5B200E8E523 /* BeGTE.h in Headers */,
 				34D7C4611BB9B5F100E8E523 /* CDRSpecHelper.h in Headers */,
 				34D7C4401BB9B5B900E8E523 /* AnInstanceOf.h in Headers */,
+				F7C9BC071D45E4E000B694C0 /* CDRRunState.h in Headers */,
 				34D7C4601BB9B5F100E8E523 /* CDRSpecFailure.h in Headers */,
 				34D7C43D1BB9B5B200E8E523 /* RespondTo.h in Headers */,
 				34D7C42E1BB9B5B200E8E523 /* Base.h in Headers */,
@@ -2656,6 +2711,7 @@
 				34D7C4341BB9B5B200E8E523 /* BeLessThan.h in Headers */,
 				34D7C4271BB9B59200E8E523 /* StubbedMethod.h in Headers */,
 				34D7C40C1BB9B54A00E8E523 /* CDRReportDispatcher.h in Headers */,
+				F7C9BC0E1D45E4EC00B694C0 /* CDRStateTracking.h in Headers */,
 				34D7C4151BB9B55500E8E523 /* CDRRuntimeUtilities.h in Headers */,
 				34D7C43A1BB9B5B200E8E523 /* Equal.h in Headers */,
 				34D7C44C1BB9B5DF00E8E523 /* ActualValue.h in Headers */,
@@ -2718,6 +2774,7 @@
 				34D7C4111BB9B54F00E8E523 /* NSInvocation+CDRXExample.h in Headers */,
 				34D7C43E1BB9B5B900E8E523 /* BeEmpty.h in Headers */,
 				34D7C45D1BB9B5F100E8E523 /* CDRHooks.h in Headers */,
+				F7C9BC0A1D45E4E400B694C0 /* CDRStateTracker.h in Headers */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -2729,6 +2786,7 @@
 				AE4865A51B0690AF005DB302 /* Argument.h in Headers */,
 				AE4865A61B0690AF005DB302 /* ValueArgument.h in Headers */,
 				AE4865A71B0690AF005DB302 /* AnyInstanceArgument.h in Headers */,
+				F7C9BC091D45E4E100B694C0 /* CDRRunState.h in Headers */,
 				AE4865A81B0690AF005DB302 /* ReturnValue.h in Headers */,
 				AE4865A91B0690AF005DB302 /* AnyArgument.h in Headers */,
 				AE4865AA1B0690AF005DB302 /* AnyInstanceOfClassArgument.h in Headers */,
@@ -2759,6 +2817,7 @@
 				AE4865C21B0690B0005DB302 /* BeTruthy.h in Headers */,
 				AE4865C31B0690B0005DB302 /* ConformTo.h in Headers */,
 				AE4865C41B0690B0005DB302 /* Equal.h in Headers */,
+				F7C9BC101D45E4ED00B694C0 /* CDRStateTracking.h in Headers */,
 				AE4865C51B0690B0005DB302 /* Exist.h in Headers */,
 				AE4865C61B0690B0005DB302 /* RaiseException.h in Headers */,
 				AE4865C71B0690B0005DB302 /* RespondTo.h in Headers */,
@@ -2821,6 +2880,7 @@
 				AE4865661B06769F005DB302 /* CDRRuntimeUtilities.h in Headers */,
 				AE4865B21B0690AF005DB302 /* RejectedMethod.h in Headers */,
 				AE4865B31B0690AF005DB302 /* StubbedMethod.h in Headers */,
+				F7C9BC0C1D45E4E500B694C0 /* CDRStateTracker.h in Headers */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -2856,11 +2916,13 @@
 				AE4A9458187F7D8F008566F5 /* BeFalsy.h in Headers */,
 				AE18A7CE13F453CC00C8872C /* BeSameInstanceAs.h in Headers */,
 				AEF8FB0719E6000E00DD4FE4 /* CDRVersion.h in Headers */,
+				F7C9BC011D45E16200B694C0 /* CDRRunState.h in Headers */,
 				34640DA81B6964FE0083EB01 /* CDRTypeUtilities.h in Headers */,
 				B86B685F1A1326E200F283F7 /* OSXGeometryStringifiers.h in Headers */,
 				2234907D18009DA6001C8E8D /* CDRHooks.h in Headers */,
 				AE18A7CF13F453CC00C8872C /* BeTruthy.h in Headers */,
 				AE18A7D013F453CC00C8872C /* Equal.h in Headers */,
+				F7C9BC0D1D45E4E600B694C0 /* CDRStateTracker.h in Headers */,
 				AE18A7D313F45BE500C8872C /* ComparatorsBase.h in Headers */,
 				AE0F354719E7059D00B9F116 /* OSXGeometryCompareEqual.h in Headers */,
 				AE18A7D613F45BFC00C8872C /* ComparatorsContainer.h in Headers */,
@@ -2879,6 +2941,7 @@
 				AE9AA67B15AB72DA00617E1A /* CDRClassFake.h in Headers */,
 				AE74902F15B45E80008EA127 /* CDRProtocolFake.h in Headers */,
 				AE9AA67815AB601500617E1A /* HaveReceived.h in Headers */,
+				F7C9BC111D45E4ED00B694C0 /* CDRStateTracking.h in Headers */,
 				AEF32FF2145A2D79002F93BB /* BeGreaterThan.h in Headers */,
 				AE597B4115B0638B00EEF305 /* InvocationMatcher.h in Headers */,
 				AEF32FF4145A2E91002F93BB /* CompareEqual.h in Headers */,
@@ -3499,10 +3562,12 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				F71C2F391D3DADD0003B37DC /* CedarTestSpecBuilder.m in Sources */,
 				F7BBE7D31B43A852009547F0 /* CedarDoubleSharedExamples.mm in Sources */,
 				F78FDA161B43AA8C0054C768 /* CedarNiceFakeSharedExamples.mm in Sources */,
 				1F45A3CE180E4796003C1E36 /* SpecBundleApplicationTests.mm in Sources */,
 				AE34722A19C118C9005CA6F1 /* SpecSpec.mm in Sources */,
+				F7C9BBF01D3E83F100B694C0 /* CDRSpecRunSpec.mm in Sources */,
 				F78FDA181B43AA8F0054C768 /* CedarOrdinaryFakeSharedExamples.mm in Sources */,
 				F78FDA1D1B43ABBC0054C768 /* ExpectFailureWithMessage.mm in Sources */,
 				1F45A3E3180E4A1C003C1E36 /* SpecBundleApplicationTestsWithXCTest.m in Sources */,
@@ -3529,6 +3594,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				346262461B9954E0002CAEBD /* CDRClassFake.mm in Sources */,
+				F7C9BBF91D3E860100B694C0 /* CDRStateTracker.m in Sources */,
 				346262701B99569B002CAEBD /* CDRSpecHelper.m in Sources */,
 				346262451B9954E0002CAEBD /* CDRSpy.mm in Sources */,
 				346262691B99569B002CAEBD /* CDRExampleGroup.m in Sources */,
@@ -3578,6 +3644,7 @@
 				3462624F1B9954E4002CAEBD /* AnyInstanceArgument.mm in Sources */,
 				3462624E1B9954E0002CAEBD /* CDRSpyInfo.mm in Sources */,
 				346262731B99569B002CAEBD /* CDRNil.m in Sources */,
+				F7C9BC041D45E19B00B694C0 /* CDRRunState.m in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -3588,6 +3655,7 @@
 				34FD463B1B99D25000257186 /* ObjectWithValueEquality.m in Sources */,
 				34D181A11BC7F0FF0087EC0D /* BlockMatcher_ARCSpecSpec.mm in Sources */,
 				34FD465B1B99D2E300257186 /* CedarNiceFakeSharedExamples.mm in Sources */,
+				F71C2F3A1D3DADD1003B37DC /* CedarTestSpecBuilder.m in Sources */,
 				34FD46471B99D2B000257186 /* BeNilSpec.mm in Sources */,
 				34FD465C1B99D2E300257186 /* CedarOrdinaryFakeSharedExamples.mm in Sources */,
 				34FD46531B99D2B900257186 /* UIKitEqualSpec.mm in Sources */,
@@ -3645,6 +3713,7 @@
 				34FD46481B99D2B000257186 /* BeSameInstanceAs_ARCSpec.mm in Sources */,
 				34FD46671B99D2F900257186 /* CDRNilSpec.mm in Sources */,
 				34FD46591B99D2E300257186 /* CedarDoubleARCSharedExamples.mm in Sources */,
+				F7C9BBF11D3E83F200B694C0 /* CDRSpecRunSpec.mm in Sources */,
 				34FD46401B99D2B000257186 /* BeFalsySpec.mm in Sources */,
 				34FD46571B99D2E300257186 /* CDRProtocolFakeSpec.mm in Sources */,
 			);
@@ -3668,6 +3737,7 @@
 				34D7C3F01BB9B52200E8E523 /* CDRTeamCityReporter.m in Sources */,
 				34D7C3D21BB9B4D600E8E523 /* AnyInstanceArgument.mm in Sources */,
 				34D7C3F91BB9B52E00E8E523 /* CDRExampleBase.m in Sources */,
+				F7C9BBFA1D3E860200B694C0 /* CDRStateTracker.m in Sources */,
 				34D7C3D51BB9B4D600E8E523 /* AnyInstanceConformingToProtocolArgument.mm in Sources */,
 				34D7C4031BB9B52E00E8E523 /* CDRTypeUtilities.m in Sources */,
 				34D7C3DA1BB9B4D600E8E523 /* CDRFake.mm in Sources */,
@@ -3709,6 +3779,7 @@
 				34D7C4001BB9B52E00E8E523 /* CDRSpecFailure.m in Sources */,
 				34D7C3E91BB9B51E00E8E523 /* CDROTestNamer.m in Sources */,
 				34D7C3DC1BB9B4D600E8E523 /* RejectedMethod.mm in Sources */,
+				F7C9BC051D45E19B00B694C0 /* CDRRunState.m in Sources */,
 				34D7C3EE1BB9B52200E8E523 /* CDROTestReporter.m in Sources */,
 				34D7C3F51BB9B52700E8E523 /* CDRXCTestObserver.m in Sources */,
 				34D7C3E31BB9B51100E8E523 /* NSBundle+MainBundleHijack.m in Sources */,
@@ -3751,6 +3822,7 @@
 				34D7C4AA1BB9C6C400E8E523 /* CDRSpecSpec.mm in Sources */,
 				34D7C4871BB9C66000E8E523 /* CedarApplicationDelegateSpec.mm in Sources */,
 				34D7C4AD1BB9C6C400E8E523 /* CDRSymbolicatorSpec.mm in Sources */,
+				F7C9BBF21D3E83F200B694C0 /* CDRSpecRunSpec.mm in Sources */,
 				34D7C4A11BB9C69100E8E523 /* ExpectFailureWithMessage.mm in Sources */,
 				34D7C4A61BB9C69A00E8E523 /* CedarDoubleSharedExamples.mm in Sources */,
 				34D7C4B31BB9C6C700E8E523 /* CDRNilSpec.mm in Sources */,
@@ -3790,6 +3862,7 @@
 				34D7C48B1BB9C67C00E8E523 /* BeFalsySpec.mm in Sources */,
 				34D7C4A91BB9C69A00E8E523 /* HaveReceivedSpec.mm in Sources */,
 				34D7C4A01BB9C68E00E8E523 /* ShouldSyntaxSpec.mm in Sources */,
+				F71C2F3B1D3DADD1003B37DC /* CedarTestSpecBuilder.m in Sources */,
 				34D7C4951BB9C67C00E8E523 /* BeTruthySpec.mm in Sources */,
 				34D7C4AE1BB9C6C400E8E523 /* CDRSpecFailureSpec.mm in Sources */,
 			);
@@ -3821,6 +3894,7 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				F71C2F381D3DAD71003B37DC /* CedarTestSpecBuilder.m in Sources */,
 				346D1A9A1BBB3DDE00BECD4B /* main.mm in Sources */,
 				AE02E83118526E9F00414F19 /* Cedar-iOSSpec.mm in Sources */,
 			);
@@ -3868,6 +3942,7 @@
 				AE19379A1B1AC94D008C8CD8 /* UIKitEqualSpec.mm in Sources */,
 				AE1937891B1AC94D008C8CD8 /* BeGTESpec.mm in Sources */,
 				AE1937841B1AC90F008C8CD8 /* WeakReferenceCompatibilitySpec.mm in Sources */,
+				F7C9BBEE1D3E83EB00B694C0 /* CDRSpecRunSpec.mm in Sources */,
 				AE19375E1B1AC22D008C8CD8 /* CDRProtocolFakeSpec.mm in Sources */,
 				AE1937961B1AC94D008C8CD8 /* RaiseExceptionSpec.mm in Sources */,
 				AE19378B1B1AC94D008C8CD8 /* BeLessThanSpec.mm in Sources */,
@@ -3885,6 +3960,7 @@
 				AE19378C1B1AC94D008C8CD8 /* BeLTESpec.mm in Sources */,
 				AE0BF0711B8E10D8000B0EE7 /* BlockMatcher_ARCSpecSpec.mm in Sources */,
 				AE1937A31B1ACC2E008C8CD8 /* GDataXMLNode.m in Sources */,
+				F71C2F361D3DAD71003B37DC /* CedarTestSpecBuilder.m in Sources */,
 				AE19379E1B1ACAFB008C8CD8 /* CDRJUnitXMLReporterSpec.mm in Sources */,
 				AE1937981B1AC94D008C8CD8 /* BeEmptySpec.mm in Sources */,
 				AE19376B1B1AC22D008C8CD8 /* ObjCHeadersSpec.mm in Sources */,
@@ -3930,6 +4006,7 @@
 				AE4865711B067953005DB302 /* AnyInstanceOfClassArgument.mm in Sources */,
 				AE4865721B067953005DB302 /* AnyInstanceConformingToProtocolArgument.mm in Sources */,
 				AE4865731B067953005DB302 /* CDRProtocolFake.mm in Sources */,
+				F7C9BBF81D3E860100B694C0 /* CDRStateTracker.m in Sources */,
 				AE4865741B067953005DB302 /* CDRSpy.mm in Sources */,
 				AE4865751B067953005DB302 /* CDRClassFake.mm in Sources */,
 				AE4865761B067953005DB302 /* CedarDoubleImpl.mm in Sources */,
@@ -3971,6 +4048,7 @@
 				AE4865971B067954005DB302 /* CDRTestBundleRunner.m in Sources */,
 				AE4865981B067954005DB302 /* CDRRuntimeUtilities.m in Sources */,
 				AE4865991B067954005DB302 /* CDRSharedExampleGroupPool.m in Sources */,
+				F7C9BC031D45E19A00B694C0 /* CDRRunState.m in Sources */,
 				AE48659A1B067954005DB302 /* CDRSpec.m in Sources */,
 				AE48659B1B067954005DB302 /* CDRSpecFailure.m in Sources */,
 				AE48659C1B067954005DB302 /* CDRSpecHelper.m in Sources */,
@@ -3985,6 +4063,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				AE4A946118807DA6008566F5 /* RejectedMethod.mm in Sources */,
+				F7C9BBF71D3E860000B694C0 /* CDRStateTracker.m in Sources */,
 				AEEE1FF311DC27B800029872 /* CDRDefaultReporter.m in Sources */,
 				34ADD2E01921F18100B057AC /* AnyInstanceOfClassArgument.mm in Sources */,
 				AE31A2A119C0F23F00C438C1 /* CDRXCTestSuite.m in Sources */,
@@ -4034,6 +4113,7 @@
 				AEE8DBD7175FFCF3008AF18A /* CDRSpyInfo.mm in Sources */,
 				CA17999017F89C9700C38060 /* RespondTo.mm in Sources */,
 				5898ACDB8101DA643EDCCD5B /* ConformTo.mm in Sources */,
+				F7C9BC021D45E16200B694C0 /* CDRRunState.m in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -4056,6 +4136,7 @@
 				34681C3018FE4B68009D38AC /* CDRTypeUtilitiesSpec.mm in Sources */,
 				AE53B68417E7CD8D00D83D5E /* ObjectWithWeakDelegate.m in Sources */,
 				AE0F354B19E7073B00B9F116 /* OSXGeometryEqualSpecSpec.mm in Sources */,
+				F71C2F341D3DAD71003B37DC /* CedarTestSpecBuilder.m in Sources */,
 				AE80788D183C71950078C608 /* ArgumentReleaser.m in Sources */,
 				AE4A945B187F7E52008566F5 /* BeFalsySpec.mm in Sources */,
 				AEF7301D13ECC4AE00786282 /* BeInstanceOfSpec.mm in Sources */,
@@ -4085,6 +4166,7 @@
 				AE9AA68015AB748E00617E1A /* CDRClassFakeSpec.mm in Sources */,
 				AE807893183C71950078C608 /* SimpleKeyValueObserver.m in Sources */,
 				AE9AA69715ADB99800617E1A /* CedarDoubleSharedExamples.mm in Sources */,
+				F7C9BBED1D3E83E500B694C0 /* CDRSpecRunSpec.mm in Sources */,
 				AE3E8F39184FEEE900633740 /* ObjectWithCollections.m in Sources */,
 				AE74903215B45EBA008EA127 /* CDRProtocolFakeSpec.mm in Sources */,
 				343FAFEA190FDAEC0085AFEC /* DeallocNotifier.m in Sources */,
@@ -4116,6 +4198,7 @@
 				AE0C9D8F19C0C64200B4DD2B /* CDRSpec+XCTestSupport.m in Sources */,
 				AEEE223211DC2B6500029872 /* CDRExample.m in Sources */,
 				AEEE223311DC2B6500029872 /* CDRExampleBase.m in Sources */,
+				F7C9BBF61D3E85FF00B694C0 /* CDRStateTracker.m in Sources */,
 				AEEE223411DC2B6500029872 /* CDRExampleGroup.m in Sources */,
 				AEEF360819DE21ED00794484 /* CDRSpecFailure.m in Sources */,
 				AEEE223511DC2B6500029872 /* CDRFunctions.m in Sources */,
@@ -4157,6 +4240,7 @@
 				969B6F86160C678400C7C792 /* CDRSymbolicator.m in Sources */,
 				E31179D6161FD937007D3CDE /* CDRSlowTestStatistics.m in Sources */,
 				AE7F170B172730B000E1146D /* NSInvocation+Cedar.m in Sources */,
+				F7C9BC061D45E19C00B694C0 /* CDRRunState.m in Sources */,
 				AEA8962C19D0C242007D5C08 /* CDRTestBundleRunner.m in Sources */,
 				34ADD2E11921F18100B057AC /* AnyInstanceOfClassArgument.mm in Sources */,
 				AE02021A17452007009A7915 /* StringifiersBase.mm in Sources */,
@@ -4208,6 +4292,7 @@
 				34681C3118FE4B68009D38AC /* CDRTypeUtilitiesSpec.mm in Sources */,
 				AE53B68217E7BCE700D83D5E /* CedarNiceFakeSharedExamples.mm in Sources */,
 				AEF3300A145B4E3B002F93BB /* BeGTESpec.mm in Sources */,
+				F7C9BBEF1D3E83EB00B694C0 /* CDRSpecRunSpec.mm in Sources */,
 				AEF33015145B6188002F93BB /* BeLessThanSpec.mm in Sources */,
 				AEF3301F145B68D7002F93BB /* BeLTESpec.mm in Sources */,
 				966E74EE145A6CA0002E8D49 /* ShouldSyntaxSpec.mm in Sources */,
@@ -4225,6 +4310,7 @@
 				9672F0AA1615C3F40012ED58 /* CDRSpecSpec.mm in Sources */,
 				346F646F1B82D3C900F64156 /* BlockMatcherSpec.mm in Sources */,
 				E32861331604F287001FA77E /* FibonacciCalculator.m in Sources */,
+				F71C2F371D3DAD71003B37DC /* CedarTestSpecBuilder.m in Sources */,
 				96B591911630F5B10068EA5E /* ObjCHeadersSpec.mm in Sources */,
 				AE80788F183C71950078C608 /* ArgumentReleaser.m in Sources */,
 				AE7DD11217296CB20058EB3B /* CedarApplicationDelegateSpec.mm in Sources */,

--- a/Source/CDRFunctions.m
+++ b/Source/CDRFunctions.m
@@ -11,6 +11,7 @@
 #import "CDROTestNamer.h"
 #import "CDRVersion.h"
 #import "CDRSpecRun.h"
+#import "CDRStateTracker.h"
 
 static NSString * const CDRBuildVersionKey = @"CDRBuildVersionSHA";
 
@@ -332,7 +333,9 @@ void __attribute__((weak)) __gcov_flush(void) {
 
 int CDRRunSpecsWithCustomExampleReporters(NSArray *reporters) {
     @autoreleasepool {
-        CDRSpecRun *run = [[CDRSpecRun alloc] initWithExampleReporters:reporters];
+        CDRStateTracker *stateTracker = [[[CDRStateTracker alloc] init] autorelease];
+        CDRSpecRun *run = [[CDRSpecRun alloc] initWithStateTracker:stateTracker
+                                                  exampleReporters:reporters];
 
         int result = [run performSpecRun:^{
             [run.rootGroups makeObjectsPerformSelector:@selector(runWithDispatcher:) withObject:run.dispatcher];

--- a/Source/CDRRunState.m
+++ b/Source/CDRRunState.m
@@ -1,0 +1,11 @@
+#import "CDRRunState.h"
+
+static CedarRunState CDRCurrentRunState = CedarRunStateNotYetStarted;
+
+CedarRunState CDRCurrentState() {
+    return CDRCurrentRunState;
+}
+
+void CDRSetCurrentRunState(CedarRunState runState) {
+    CDRCurrentRunState = runState;
+}

--- a/Source/CDRSpec.m
+++ b/Source/CDRSpec.m
@@ -1,15 +1,46 @@
+#import <objc/runtime.h>
+
 #import "CDRSpec.h"
 #import "CDRExample.h"
-#import "CDRExampleGroup.h"
-#import "CDRSpecFailure.h"
+#import "CDRRunState.h"
 #import "CDRSpecHelper.h"
+#import "CDRSpecFailure.h"
+#import "CDRExampleGroup.h"
 #import "CDRSymbolicator.h"
-#import <objc/runtime.h>
+
+#define with_stack_address(b) \
+((b.stackAddress = CDRCallerStackAddress()), b)
 
 CDRSpec *CDR_currentSpec;
 
-static void(^placeholderPendingTestBlock)() = ^{ it(@"is pending", PENDING); };
+#pragma mark - Spec Validation
 
+// runs validation when it(), context(), describe() are invoked
+// generally this is a useful feature, but you may disable it if you
+// care to do metaprogramming with Cedar specs
+// (or other usecases we couldn't imagine).
+BOOL CDR_validateSpecs = YES;
+
+void CDRDisableSpecValidation() {
+    CDR_validateSpecs = NO;
+}
+
+void CDREnableSpecValidation() {
+    CDR_validateSpecs = YES;
+}
+
+#pragma mark - static vars
+
+static void(^placeholderPendingTestBlock)() = ^{
+    BOOL originalState = CDR_validateSpecs;
+    CDR_validateSpecs = NO;
+
+    it(@"is pending", PENDING);
+
+    CDR_validateSpecs = originalState;
+};
+
+#pragma mark - public API
 void beforeEach(CDRSpecBlock block) {
     [CDR_currentSpec.currentGroup addBefore:block];
 }
@@ -18,43 +49,96 @@ void afterEach(CDRSpecBlock block) {
     [CDR_currentSpec.currentGroup addAfter:block];
 }
 
-#define with_stack_address(b) \
-    ((b.stackAddress = CDRCallerStackAddress()), b)
+void ensureCurrentSpecExists(NSString *functionName) {
+    if (!CDR_validateSpecs) {
+        return;
+    }
+
+    if (CDR_currentSpec == nil) {
+        NSString * reason = [NSString stringWithFormat:@"%@() was invoked outside of a spec. It may only be called when a spec has been defined with SPEC_BEGIN and SPEC_END macros.", functionName];
+        [[NSException exceptionWithName:NSInternalInconsistencyException
+                                 reason:reason
+                               userInfo:nil] raise];
+    }
+}
+
+void ensureTestsAreNotYetRunning(NSString *functionName) {
+    if (!CDR_validateSpecs) {
+        return;
+    }
+
+    switch (CDRCurrentState()) {
+        case CedarRunStateNotYetStarted:
+            // exceedingly unlikely
+            break;
+        case CedarRunStatePreparingTests:
+            // happy path, no-op, we should hit this branch 100% of the time
+            break;
+        case CedarRunStateRunningTests: {
+            // someone done goofed
+            NSString * reason = [NSString stringWithFormat:@"%@() was invoked during a test run. Make sure your '%@()' is not inside of an it() block.", functionName, functionName];
+            [[NSException exceptionWithName:NSInternalInconsistencyException
+                                     reason:reason
+                                   userInfo:nil] raise];
+            break;
+        }
+        case CedarRunStateFinished:
+            // someone ... REALLY done goofed
+            break;
+    }
+}
+
+CDRExampleGroup *groupFromSpecBlock(NSString *text, CDRSpecBlock block) {
+    if (!block) {
+        return groupFromSpecBlock(text, placeholderPendingTestBlock);
+    }
+
+    CDRExampleGroup *parentGroup = CDR_currentSpec.currentGroup;
+    CDRExampleGroup *group = [CDRExampleGroup groupWithText:text];
+    [parentGroup add:group];
+    CDR_currentSpec.currentGroup = group;
+
+    @try {
+        block();
+    }
+    @catch (CDRSpecFailure *failure) {
+        NSString *reason = [NSString stringWithFormat:@"Caught a spec failure before the specs began to run. Did you forget to put your assertion into an `it` block?. The failure was:\n%@", failure];
+        [[NSException exceptionWithName:NSInternalInconsistencyException reason:reason userInfo:nil] raise];
+    }
+
+    if ([group.examples count] == 0) {
+        block = placeholderPendingTestBlock;
+        block();
+    }
+    CDR_currentSpec.currentGroup = parentGroup;
+
+    return group;
+}
 
 CDRExampleGroup * describe(NSString *text, CDRSpecBlock block) {
-    CDRExampleGroup *group = nil;
-    if (block) {
-        CDRExampleGroup *parentGroup = CDR_currentSpec.currentGroup;
-        group = [CDRExampleGroup groupWithText:text];
-        [parentGroup add:group];
-        CDR_currentSpec.currentGroup = group;
+    ensureCurrentSpecExists(@"describe");
+    ensureTestsAreNotYetRunning(@"describe");
 
-        @try {
-            block();
-        }
-        @catch (CDRSpecFailure *failure) {
-            NSString *reason = [NSString stringWithFormat:@"Caught a spec failure before the specs began to run. Did you forget to put your assertion into an `it` block?. The failure was:\n%@", failure];
-            [[NSException exceptionWithName:NSInternalInconsistencyException reason:reason userInfo:nil] raise];
-        }
-
-        if ([group.examples count] == 0) {
-            block = placeholderPendingTestBlock;
-            block();
-        }
-        CDR_currentSpec.currentGroup = parentGroup;
-    } else {
-        group = describe(text, placeholderPendingTestBlock);
-    }
+    CDRExampleGroup *group = groupFromSpecBlock(text, block);
     return with_stack_address(group);
 }
 
-CDRExampleGroup* (*context)(NSString *, CDRSpecBlock) = &describe;
+CDRExampleGroup* context(NSString *text, CDRSpecBlock block) {
+    ensureCurrentSpecExists(@"context");
+    ensureTestsAreNotYetRunning(@"context");
+
+    CDRExampleGroup *group = groupFromSpecBlock(text, block);
+    return with_stack_address(group);
+}
 
 void subjectAction(CDRSpecBlock block) {
     CDR_currentSpec.currentGroup.subjectActionBlock = block;
 }
 
 CDRExample * it(NSString *text, CDRSpecBlock block) {
+    ensureCurrentSpecExists(@"it");
+    ensureTestsAreNotYetRunning(@"it");
+
     CDRExample *example = [CDRExample exampleWithText:text andBlock:block];
     [CDR_currentSpec.currentGroup add:example];
     return with_stack_address(example);
@@ -67,7 +151,10 @@ CDRExampleGroup * xdescribe(NSString *text, CDRSpecBlock block) {
     return with_stack_address(group);
 }
 
-CDRExampleGroup* (*xcontext)(NSString *, CDRSpecBlock) = &xdescribe;
+CDRExampleGroup * xcontext(NSString *text, CDRSpecBlock block) {
+    CDRExampleGroup *group = context(text, placeholderPendingTestBlock);
+    return with_stack_address(group);
+}
 
 CDRExample * xit(NSString *text, CDRSpecBlock block) {
     CDRExample *example = it(text, PENDING);
@@ -82,7 +169,11 @@ CDRExampleGroup * fdescribe(NSString *text, CDRSpecBlock block) {
     return with_stack_address(group);
 }
 
-CDRExampleGroup* (*fcontext)(NSString *, CDRSpecBlock) = &fdescribe;
+CDRExampleGroup * fcontext(NSString *text, CDRSpecBlock block) {
+    CDRExampleGroup *group = context(text, block);
+    group.focused = YES;
+    return with_stack_address(group);
+}
 
 CDRExample * fit(NSString *text, CDRSpecBlock block) {
     CDRExample *example = it(text, block);
@@ -118,7 +209,9 @@ void fail(NSString *reason) {
 }
 
 - (void)commonInit {
-    self.rootGroup = [[[CDRExampleGroup alloc] initWithText:[[self class] description] isRoot:YES] autorelease];
+    NSString *text = self.class.description;
+    self.rootGroup = [[[CDRExampleGroup alloc] initWithText:text
+                                                     isRoot:YES] autorelease];
     self.rootGroup.parent = [CDRSpecHelper specHelper];
     self.currentGroup = self.rootGroup;
     self.symbolicator = [[[CDRSymbolicator alloc] init] autorelease];

--- a/Source/CDRSpec.m
+++ b/Source/CDRSpec.m
@@ -70,6 +70,9 @@ void ensureTestsAreNotYetRunning(NSString *functionName) {
     switch (CDRCurrentState()) {
         case CedarRunStateNotYetStarted:
             // exceedingly unlikely
+            [[NSException exceptionWithName:NSInternalInconsistencyException
+                                    reason:@"%@() was invoked BEFORE cedar started running at all. It's unclear how this happened, but this probably represents a bug in your tests. (Please consider opening a github issue if you're fairly certain your test setup is correct)"
+                                   userInfo:nil] raise];
             break;
         case CedarRunStatePreparingTests:
             // happy path, no-op, we should hit this branch 100% of the time
@@ -84,6 +87,9 @@ void ensureTestsAreNotYetRunning(NSString *functionName) {
         }
         case CedarRunStateFinished:
             // someone ... REALLY done goofed
+            [[NSException exceptionWithName:NSInternalInconsistencyException
+                                     reason:@"%@() was invoked AFTER cedar finished running all its tests. It's unclear how this happened, but this probably represents a bug in your tests. (Please consider opening a github issue if you're fairly certain your test setup is correct)"
+                                   userInfo:nil] raise];
             break;
     }
 }

--- a/Source/CDRStateTracker.h
+++ b/Source/CDRStateTracker.h
@@ -1,0 +1,6 @@
+#import <Foundation/Foundation.h>
+#import "CDRStateTracking.h"
+
+@interface CDRStateTracker : NSObject <CDRStateTracking>
+
+@end

--- a/Source/CDRStateTracker.m
+++ b/Source/CDRStateTracker.m
@@ -1,0 +1,18 @@
+#import "CDRStateTracker.h"
+#import "CDRRunState.h"
+
+@implementation CDRStateTracker
+
+- (void)didStartPreparingTests {
+    CDRSetCurrentRunState(CedarRunStatePreparingTests);
+}
+
+- (void)didStartRunningTests {
+    CDRSetCurrentRunState(CedarRunStateRunningTests);
+}
+
+- (void)didFinishRunningTests {
+    CDRSetCurrentRunState(CedarRunStateFinished);
+}
+
+@end

--- a/Source/CDRStateTracking.h
+++ b/Source/CDRStateTracking.h
@@ -1,0 +1,9 @@
+#import <Foundation/Foundation.h>
+
+@protocol CDRStateTracking <NSObject>
+
+- (void)didStartPreparingTests;
+- (void)didStartRunningTests;
+- (void)didFinishRunningTests;
+
+@end

--- a/Source/CDRTypeUtilities.m
+++ b/Source/CDRTypeUtilities.m
@@ -129,7 +129,7 @@ static NSCharacterSet *typeEncodingModifiersCharacterSet;
     return nil;
 }
 
-+ (id)boxedObjectOfBytes:(const char *)argBuffer ofObjCType:(const char *)argType {
++ (id)boxedObjectOfBytes:(const void *)argBuffer ofObjCType:(const char *)argType {
 #define IS_TYPE(TYPE) (strncmp(argType, @encode(TYPE), sizeof(@encode(TYPE))) == 0)
 #define CONVERT_TYPE(TYPE) ({TYPE i; \
 memcpy(&i, argBuffer, sizeof(TYPE)); \
@@ -141,10 +141,10 @@ i;})
     } else if (IS_TYPE(void(^)())) {
         return (id)*((void **)argBuffer) ?: [CDRNil nilObject];
     } else if (IS_TYPE(char *)) {
-        BOOL isNotNull = *(char **)argBuffer != '\0';
+        BOOL isNotNull = *(char **)argBuffer != NULL;
         return isNotNull ? [NSString stringWithUTF8String:*(char **)argBuffer] : [CDRNil nilObject];
     } else if (IS_TYPE(const char *)) {
-        BOOL isNotNull = *(const char **)argBuffer != '\0';
+        BOOL isNotNull = *(const char **)argBuffer != NULL;
         return isNotNull ? [NSString stringWithUTF8String:*(const char **)argBuffer] : [CDRNil nilObject];
     } else if (IS_TYPE(SEL)) {
         return CONVERT_TYPE(SEL) ? NSStringFromSelector(CONVERT_TYPE(SEL)) : [CDRNil nilObject];

--- a/Source/CDRTypeUtilities.m
+++ b/Source/CDRTypeUtilities.m
@@ -141,10 +141,10 @@ i;})
     } else if (IS_TYPE(void(^)())) {
         return (id)*((void **)argBuffer) ?: [CDRNil nilObject];
     } else if (IS_TYPE(char *)) {
-        BOOL isNotNull = *argBuffer != '\0';
+        BOOL isNotNull = *(char **)argBuffer != '\0';
         return isNotNull ? [NSString stringWithUTF8String:*(char **)argBuffer] : [CDRNil nilObject];
     } else if (IS_TYPE(const char *)) {
-        BOOL isNotNull = *argBuffer != '\0';
+        BOOL isNotNull = *(const char **)argBuffer != '\0';
         return isNotNull ? [NSString stringWithUTF8String:*(const char **)argBuffer] : [CDRNil nilObject];
     } else if (IS_TYPE(SEL)) {
         return CONVERT_TYPE(SEL) ? NSStringFromSelector(CONVERT_TYPE(SEL)) : [CDRNil nilObject];

--- a/Source/Extensions/NSInvocation+Cedar.m
+++ b/Source/Extensions/NSInvocation+Cedar.m
@@ -83,7 +83,8 @@ static char COPIED_BLOCKS_KEY;
         [self getArgument:argBuffer atIndex:argIndex];
 
         const char *argType = [methodSignature getArgumentTypeAtIndex:argIndex];
-        [args addObject:[CDRTypeUtilities boxedObjectOfBytes:argBuffer ofObjCType:argType]];
+        [args addObject:[CDRTypeUtilities boxedObjectOfBytes:(const void *)argBuffer
+                                                  ofObjCType:argType]];
     }
     return args;
 }

--- a/Source/Headers/Project/CDRRunState.h
+++ b/Source/Headers/Project/CDRRunState.h
@@ -1,0 +1,11 @@
+#import <Foundation/Foundation.h>
+
+typedef NS_ENUM(NSInteger, CedarRunState) {
+    CedarRunStateNotYetStarted   = 0,
+    CedarRunStatePreparingTests  = 1,
+    CedarRunStateRunningTests    = 2,
+    CedarRunStateFinished        = 3
+};
+
+OBJC_EXPORT CedarRunState CDRCurrentState();
+OBJC_EXPORT void CDRSetCurrentRunState(CedarRunState);

--- a/Source/Headers/Project/CDRSpecRun.h
+++ b/Source/Headers/Project/CDRSpecRun.h
@@ -1,4 +1,5 @@
 #import <Foundation/Foundation.h>
+#import "CDRStateTracking.h"
 
 @class CDRReportDispatcher;
 
@@ -9,7 +10,8 @@
 @property (nonatomic, retain, readonly) CDRReportDispatcher *dispatcher;
 @property (nonatomic, assign, readonly) unsigned int seed;
 
-- (instancetype)initWithExampleReporters:(NSArray *)reporters;
+- (instancetype)initWithStateTracker:(id<CDRStateTracking>)stateTracker
+                    exampleReporters:(NSArray *)reporters;
 - (int)performSpecRun:(void (^)(void))runBlock;
 
 @end

--- a/Source/Headers/Project/CDRTypeUtilities.h
+++ b/Source/Headers/Project/CDRTypeUtilities.h
@@ -2,5 +2,5 @@
 
 @interface CDRTypeUtilities : NSObject
 + (NSString *)typeNameForEncoding:(const char *)encoding;
-+ (id)boxedObjectOfBytes:(const char *)argBuffer ofObjCType:(const char *)argType;
++ (id)boxedObjectOfBytes:(const void *)argBuffer ofObjCType:(const char *)argType;
 @end

--- a/Source/Headers/Public/CDRFunctions.h
+++ b/Source/Headers/Public/CDRFunctions.h
@@ -17,8 +17,8 @@ NSArray *CDRReportersToRun();
 NSString *CDRGetTestBundleExtension();
 void CDRSuppressStandardPipesWhileLoadingClasses();
 
+NS_ASSUME_NONNULL_END
+
 #ifdef __cplusplus
 }
 #endif
-
-NS_ASSUME_NONNULL_END

--- a/Source/Headers/Public/CDRSpec.h
+++ b/Source/Headers/Public/CDRSpec.h
@@ -16,24 +16,30 @@ extern const __nullable CDRSpecBlock PENDING;
 #ifdef __cplusplus
 extern "C" {
 #endif
-void beforeEach(CDRSpecBlock);
+
+    void beforeEach(CDRSpecBlock);
 void afterEach(CDRSpecBlock);
+void subjectAction(CDRSpecBlock);
 
 CDRExampleGroup * describe(NSString *, __nullable CDRSpecBlock);
-extern CDRExampleGroup* __nonnull (*__nonnull context)(NSString *, __nullable CDRSpecBlock);
-
+CDRExampleGroup * context(NSString *, __nullable CDRSpecBlock);
 CDRExample * it(NSString *, __nullable CDRSpecBlock);
 
+
 CDRExampleGroup * xdescribe(NSString *, __nullable CDRSpecBlock);
-extern CDRExampleGroup* __nonnull (*__nonnull xcontext)(NSString *, __nullable CDRSpecBlock);
-void subjectAction(CDRSpecBlock);
+CDRExampleGroup* xcontext(NSString *, __nullable CDRSpecBlock);
 CDRExample * xit(NSString *, __nullable CDRSpecBlock);
 
+
 CDRExampleGroup * fdescribe(NSString *, __nullable CDRSpecBlock);
-extern CDRExampleGroup* __nonnull (*__nonnull fcontext)(NSString *, __nullable CDRSpecBlock);
+CDRExampleGroup * fcontext(NSString *, __nullable CDRSpecBlock);
 CDRExample * fit(NSString *, __nullable CDRSpecBlock);
 
 void fail(NSString *);
+
+void CDREnableSpecValidation();
+void CDRDisableSpecValidation();
+
 #ifdef __cplusplus
 }
 #endif

--- a/Source/XCTest/CDRXCTestFunctions.m
+++ b/Source/XCTest/CDRXCTestFunctions.m
@@ -1,4 +1,6 @@
 #import <Foundation/Foundation.h>
+#import <objc/runtime.h>
+
 #import "CDRFunctions.h"
 #import "CDRPrivateFunctions.h"
 #import "CDRXCTestSuite.h"
@@ -7,7 +9,7 @@
 #import "CDRReportDispatcher.h"
 #import "CDRSpec.h"
 #import "CDRSpecRun.h"
-#import <objc/runtime.h>
+#import "CDRStateTracker.h"
 
 id CDRCreateXCTestSuite() {
     Class testSuiteClass = NSClassFromString(@"XCTestSuite") ?: NSClassFromString(@"SenTestSuite");
@@ -19,7 +21,9 @@ id CDRCreateXCTestSuite() {
                                                          templateClass:[CDRXCTestSuite class]];
     }
 
-    CDRSpecRun *run = [[[CDRSpecRun alloc] initWithExampleReporters:CDRReportersToRun()] autorelease];
+    CDRStateTracker *stateTracker = [[[CDRStateTracker alloc] init] autorelease];
+    CDRSpecRun *run = [[[CDRSpecRun alloc] initWithStateTracker:stateTracker
+                                               exampleReporters:CDRReportersToRun()] autorelease];
     return [[[testSuiteSubclass alloc] initWithSpecRun:run] autorelease];
 }
 

--- a/Spec/CDRHooksSpec.mm
+++ b/Spec/CDRHooksSpec.mm
@@ -69,13 +69,19 @@ describe(@"CDRHooks", ^{
         conformantClassAfterEachWasTriggered__ =
         conformantClassAfterEachWasTriggeredBeforeSpecAfterEach__ = NO;
 
+        CDRDisableSpecValidation();
+
         CDRSpec *dummySpec = [[[DummySpecForTestingHooks class] alloc] init];
         [dummySpec defineBehaviors];
 
-        CDRSpecRun *specRun = [[CDRSpecRun alloc] initWithExampleReporters:@[]];
+        id<CDRStateTracking> fakeStateTracker = nice_fake_for(@protocol(CDRStateTracking));
+        CDRSpecRun *specRun = [[CDRSpecRun alloc] initWithStateTracker:fakeStateTracker
+                                                      exampleReporters:@[]];
         [specRun performSpecRun:^{
             [dummySpec.rootGroup runWithDispatcher:specRun.dispatcher];
         }];
+
+        CDREnableSpecValidation();
     });
 
     describe(@"+beforeEach", ^{

--- a/Spec/CDRSpecRunSpec.mm
+++ b/Spec/CDRSpecRunSpec.mm
@@ -1,0 +1,45 @@
+#import <Cedar/Cedar.h>
+#import "CDRSpecRun.h"
+#import "CDRStateTracking.h"
+
+using namespace Cedar::Matchers;
+using namespace Cedar::Doubles;
+
+SPEC_BEGIN(CDRSpecRunSpec)
+
+describe(@"CDRSpecRun", ^{
+    __block CDRSpecRun *subject;
+    __block id<CDRStateTracking, CedarDouble> stateTracker;
+
+    beforeEach(^{
+        CDRDisableSpecValidation();
+    });
+
+    afterEach(^{
+        CDREnableSpecValidation();
+    });
+
+    beforeEach(^{
+        stateTracker = fake_for(@protocol(CDRStateTracking));
+        stateTracker stub_method(@selector(didStartPreparingTests));
+        subject = [[CDRSpecRun alloc] initWithStateTracker:stateTracker
+                                          exampleReporters:@[]];
+    });
+
+    it(@"should move the state into CedarRunStatePreparingTests", ^{
+        stateTracker should have_received(@selector(didStartPreparingTests));
+    });
+
+    it(@"should change the state to running tests and then be finished", ^{
+        stateTracker stub_method(@selector(didStartRunningTests));
+
+        [subject performSpecRun:^{
+            stateTracker should have_received(@selector(didStartRunningTests));
+            stateTracker stub_method(@selector(didFinishRunningTests));
+        }];
+
+        stateTracker should have_received(@selector(didFinishRunningTests));
+    });
+});
+
+SPEC_END

--- a/Spec/CDRSymbolicatorSpec.mm
+++ b/Spec/CDRSymbolicatorSpec.mm
@@ -45,6 +45,15 @@ describe(@"CDRSymbolicator", ^{
             __block CDRExample *example;
             __block CDRExampleGroup *group;
 
+            beforeEach(^{
+                // disabled so we can call it() directly
+                CDRDisableSpecValidation();
+            });
+
+            afterEach(^{
+                CDREnableSpecValidation();
+            });
+
             void (^verifyFileNameAndLineNumber)(CDRExampleBase *, NSString *, int) =
                 ^(CDRExampleBase *b, NSString *fileName, int lineNumber) {
                     NSNumber *address = [NSNumber numberWithUnsignedInteger:b.stackAddress];

--- a/Spec/CDRTypeUtilitiesSpec.mm
+++ b/Spec/CDRTypeUtilitiesSpec.mm
@@ -79,6 +79,11 @@ describe(@"CDRTypeUtilities", ^{
             [CDRTypeUtilities boxedObjectOfBytes:(const void *)&text ofObjCType:@encode(const char *)] should equal(@"Hello world!");
         });
 
+        it(@"should return a NSString for a non-null but empty c string", ^{
+            const char *text = "";
+            [CDRTypeUtilities boxedObjectOfBytes:(const void *)&text ofObjCType:@encode(const char *)] should equal(@"");
+        });
+
         it(@"should return the objective-c object it was given", ^{
             id foo = @"bar";
             [CDRTypeUtilities boxedObjectOfBytes:(const void *)&foo ofObjCType:@encode(id)] should be_same_instance_as(foo);

--- a/Spec/CDRTypeUtilitiesSpec.mm
+++ b/Spec/CDRTypeUtilitiesSpec.mm
@@ -16,114 +16,114 @@ describe(@"CDRTypeUtilities", ^{
 
         it(@"should return a boxed number for int", ^{
             int i = 23456;
-            [CDRTypeUtilities boxedObjectOfBytes:(const char *)&i ofObjCType:@encode(int)] should equal(@(i));
+            [CDRTypeUtilities boxedObjectOfBytes:(const void *)&i ofObjCType:@encode(int)] should equal(@(i));
         });
 
         it(@"should return a boxed number for short", ^{
             short i = 4456;
-            [CDRTypeUtilities boxedObjectOfBytes:(const char *)&i ofObjCType:@encode(short)] should equal(@(i));
+            [CDRTypeUtilities boxedObjectOfBytes:(const void *)&i ofObjCType:@encode(short)] should equal(@(i));
         });
 
         it(@"should return a boxed number for long", ^{
             long i = 5345;
-            [CDRTypeUtilities boxedObjectOfBytes:(const char *)&i ofObjCType:@encode(long)] should equal(@(i));
+            [CDRTypeUtilities boxedObjectOfBytes:(const void *)&i ofObjCType:@encode(long)] should equal(@(i));
         });
 
         it(@"should return a boxed number for a long long", ^{
             long long i = 63453;
-            [CDRTypeUtilities boxedObjectOfBytes:(const char *)&i ofObjCType:@encode(long long)] should equal(@(i));
+            [CDRTypeUtilities boxedObjectOfBytes:(const void *)&i ofObjCType:@encode(long long)] should equal(@(i));
         });
 
         it(@"should return a boxed number for unsigned char", ^{
             unsigned char c = 'c';
-            [CDRTypeUtilities boxedObjectOfBytes:(const char *)&c ofObjCType:@encode(unsigned char)] should equal(@(c));
+            [CDRTypeUtilities boxedObjectOfBytes:(const void *)&c ofObjCType:@encode(unsigned char)] should equal(@(c));
         });
 
         it(@"should return a boxed number for unsigned int", ^{
             unsigned int i = 21234;
-            [CDRTypeUtilities boxedObjectOfBytes:(const char *)&i ofObjCType:@encode(unsigned int)] should equal(@(i));
+            [CDRTypeUtilities boxedObjectOfBytes:(const void *)&i ofObjCType:@encode(unsigned int)] should equal(@(i));
         });
 
         it(@"should return a boxed number for unsigned short", ^{
             unsigned short i = 4456;
-            [CDRTypeUtilities boxedObjectOfBytes:(const char *)&i ofObjCType:@encode(unsigned short)] should equal(@(i));
+            [CDRTypeUtilities boxedObjectOfBytes:(const void *)&i ofObjCType:@encode(unsigned short)] should equal(@(i));
         });
 
-        it(@"should return a boxed nubmer for unsigned long", ^{
+        it(@"should return a boxed number for unsigned long", ^{
             unsigned long long i = 6346;
-            [CDRTypeUtilities boxedObjectOfBytes:(const char *)&i ofObjCType:@encode(long long)] should equal(@(i));
+            [CDRTypeUtilities boxedObjectOfBytes:(const void *)&i ofObjCType:@encode(long long)] should equal(@(i));
         });
 
         it(@"should return a boxed number for unsigned long long", ^{
             unsigned long long i = 7234;
-            [CDRTypeUtilities boxedObjectOfBytes:(const char *)&i ofObjCType:@encode(unsigned long long)] should equal(@(i));
+            [CDRTypeUtilities boxedObjectOfBytes:(const void *)&i ofObjCType:@encode(unsigned long long)] should equal(@(i));
         });
 
         it(@"should return a boxed number for float", ^{
             float i = 1.5f;
-            [CDRTypeUtilities boxedObjectOfBytes:(const char *)&i ofObjCType:@encode(float)] should equal(@(i));
+            [CDRTypeUtilities boxedObjectOfBytes:(const void *)&i ofObjCType:@encode(float)] should equal(@(i));
         });
 
         it(@"should return a boxed number for double", ^{
             double i = 1.5;
-            [CDRTypeUtilities boxedObjectOfBytes:(const char *)&i ofObjCType:@encode(double)] should equal(@(i));
+            [CDRTypeUtilities boxedObjectOfBytes:(const void *)&i ofObjCType:@encode(double)] should equal(@(i));
         });
 
         it(@"should return a boxed number for a non-objc bool", ^{
             bool b = true;
-            [CDRTypeUtilities boxedObjectOfBytes:(const char *)&b ofObjCType:@encode(bool)] should equal(@YES);
+            [CDRTypeUtilities boxedObjectOfBytes:(const void *)&b ofObjCType:@encode(bool)] should equal(@YES);
         });
 
         it(@"should return a NSString for a c string", ^{
             const char *text = "Hello world!";
-            [CDRTypeUtilities boxedObjectOfBytes:(const char *)&text ofObjCType:@encode(const char *)] should equal(@"Hello world!");
+            [CDRTypeUtilities boxedObjectOfBytes:(const void *)&text ofObjCType:@encode(const char *)] should equal(@"Hello world!");
         });
 
         it(@"should return the objective-c object it was given", ^{
             id foo = @"bar";
-            [CDRTypeUtilities boxedObjectOfBytes:(const char *)&foo ofObjCType:@encode(id)] should be_same_instance_as(foo);
+            [CDRTypeUtilities boxedObjectOfBytes:(const void *)&foo ofObjCType:@encode(id)] should be_same_instance_as(foo);
         });
 
         describe(@"given a nil value", ^{
             context(@"typed as an object", ^{
                 it(@"should return CDRNil", ^{
                     id nilParam = nil;
-                    [CDRTypeUtilities boxedObjectOfBytes:(const char *)&nilParam ofObjCType:@encode(id)] should equal([CDRNil nilObject]);
+                    [CDRTypeUtilities boxedObjectOfBytes:(const void *)&nilParam ofObjCType:@encode(id)] should equal([CDRNil nilObject]);
                 });
             });
 
             context(@"typed as Class", ^{
                 it(@"should return CDRNil", ^{
                     Class nilParam = nil;
-                    [CDRTypeUtilities boxedObjectOfBytes:(const char *)&nilParam ofObjCType:@encode(Class)] should equal([CDRNil nilObject]);
+                    [CDRTypeUtilities boxedObjectOfBytes:(const void *)&nilParam ofObjCType:@encode(Class)] should equal([CDRNil nilObject]);
                 });
             });
 
             context(@"typed as as block", ^{
                 it(@"should return CDRNil", ^{
                     void (^nilBlock)(NSString *) = nil;
-                    [CDRTypeUtilities boxedObjectOfBytes:(const char *)&nilBlock ofObjCType:@encode(void (^)(NSString *))] should equal([CDRNil nilObject]);
+                    [CDRTypeUtilities boxedObjectOfBytes:(const void *)&nilBlock ofObjCType:@encode(void (^)(NSString *))] should equal([CDRNil nilObject]);
                 });
             });
 
             context(@"typed as a char *", ^{
                 it(@"should return CDRNil", ^{
                     char *nilCharPointer = NULL;
-                    [CDRTypeUtilities boxedObjectOfBytes:(const char *)&nilCharPointer ofObjCType:@encode(char *)] should equal([CDRNil nilObject]);
+                    [CDRTypeUtilities boxedObjectOfBytes:(const void *)&nilCharPointer ofObjCType:@encode(char *)] should equal([CDRNil nilObject]);
                 });
             });
 
             context(@"typed as a const char *", ^{
                 it(@"should return CDRNil", ^{
                     const char *foobar = NULL;
-                    [CDRTypeUtilities boxedObjectOfBytes:(const char *)&foobar ofObjCType:@encode(const char *)] should equal([CDRNil nilObject]);
+                    [CDRTypeUtilities boxedObjectOfBytes:(const void *)&foobar ofObjCType:@encode(const char *)] should equal([CDRNil nilObject]);
                 });
             });
 
             context(@"typed as a SEL", ^{
                 it(@"should return CDRNil", ^{
                     SEL mySelector = nil;
-                    [CDRTypeUtilities boxedObjectOfBytes:(const char *)&mySelector ofObjCType:@encode(SEL)] should equal([CDRNil nilObject]);
+                    [CDRTypeUtilities boxedObjectOfBytes:(const void *)&mySelector ofObjCType:@encode(SEL)] should equal([CDRNil nilObject]);
                 });
             });
 
@@ -131,44 +131,44 @@ describe(@"CDRTypeUtilities", ^{
 
         it(@"should return the class it was given", ^{
             Class aClass = [NSObject class];
-            [CDRTypeUtilities boxedObjectOfBytes:(const char *)&aClass ofObjCType:@encode(Class)] should equal(aClass);
+            [CDRTypeUtilities boxedObjectOfBytes:(const void *)&aClass ofObjCType:@encode(Class)] should equal(aClass);
         });
 
         it(@"should return a string for a selector", ^{
             SEL selector = @selector(description);
-            [CDRTypeUtilities boxedObjectOfBytes:(const char *)&selector ofObjCType:@encode(SEL)] should equal(NSStringFromSelector(selector));
+            [CDRTypeUtilities boxedObjectOfBytes:(const void *)&selector ofObjCType:@encode(SEL)] should equal(NSStringFromSelector(selector));
         });
 
         it(@"should return the objective-c block it was given", ^{
             void (^aBlock)() = ^{};
-            (id)[CDRTypeUtilities boxedObjectOfBytes:(const char *)&aBlock ofObjCType:@encode(void(^)())] should equal((id)aBlock);
+            (id)[CDRTypeUtilities boxedObjectOfBytes:(const void *)&aBlock ofObjCType:@encode(void(^)())] should equal((id)aBlock);
         });
         describe(@"given a char *", ^{
             it(@"should return an NSString when given a non-empty char *", ^{
                 char *foobar = (char *)"hello world";
-                [CDRTypeUtilities boxedObjectOfBytes:(const char *)&foobar ofObjCType:@encode(char *)] should equal(@"hello world");
+                [CDRTypeUtilities boxedObjectOfBytes:(const void *)&foobar ofObjCType:@encode(char *)] should equal(@"hello world");
             });
             it(@"should return an empty NSString when given an empty char *", ^{
                 char *foobar = (char *)"";
-                [CDRTypeUtilities boxedObjectOfBytes:(const char *)&foobar ofObjCType:@encode(char *)] should equal(@"");
+                [CDRTypeUtilities boxedObjectOfBytes:(const void *)&foobar ofObjCType:@encode(char *)] should equal(@"");
             });
         });
 
         describe(@"given a const char *", ^{
             it(@"should return a string for a non-empty const char *", ^{
                 const char *foobar = "hello world";
-                [CDRTypeUtilities boxedObjectOfBytes:(const char *)&foobar ofObjCType:@encode(const char *)] should equal(@"hello world");
+                [CDRTypeUtilities boxedObjectOfBytes:(const void *)&foobar ofObjCType:@encode(const char *)] should equal(@"hello world");
             });
 
             it(@"should return an empty string for an empty const char *", ^{
                 const char *foobar = "";
-                [CDRTypeUtilities boxedObjectOfBytes:(const char *)&foobar ofObjCType:@encode(const char *)] should equal(@"");
+                [CDRTypeUtilities boxedObjectOfBytes:(const void *)&foobar ofObjCType:@encode(const char *)] should equal(@"");
             });
         });
 
         it(@"should return an NSValue for other Types", ^{
             CGRect r = CGRectMake(1, 2, 3, 4);
-            (id)[CDRTypeUtilities boxedObjectOfBytes:(const char *)&r ofObjCType:@encode(CGRect)] should equal([NSValue valueWithBytes:&r objCType:@encode(CGRect)]);
+            (id)[CDRTypeUtilities boxedObjectOfBytes:(const void *)&r ofObjCType:@encode(CGRect)] should equal([NSValue valueWithBytes:&r objCType:@encode(CGRect)]);
         });
     });
 

--- a/Spec/CDRTypeUtilitiesSpec.mm
+++ b/Spec/CDRTypeUtilitiesSpec.mm
@@ -71,12 +71,12 @@ describe(@"CDRTypeUtilities", ^{
 
         it(@"should return a boxed number for a non-objc bool", ^{
             bool b = true;
-            [CDRTypeUtilities boxedObjectOfBytes:(const char *)&b ofObjCType:@encode(bool)] should equal(@(b));
+            [CDRTypeUtilities boxedObjectOfBytes:(const char *)&b ofObjCType:@encode(bool)] should equal(@YES);
         });
 
         it(@"should return a NSString for a c string", ^{
             const char *text = "Hello world!";
-            [CDRTypeUtilities boxedObjectOfBytes:(const char *)&text ofObjCType:@encode(char *)] should equal(@"Hello world!");
+            [CDRTypeUtilities boxedObjectOfBytes:(const char *)&text ofObjCType:@encode(const char *)] should equal(@"Hello world!");
         });
 
         it(@"should return the objective-c object it was given", ^{

--- a/Spec/Support/CedarTestSpecBuilder.h
+++ b/Spec/Support/CedarTestSpecBuilder.h
@@ -1,0 +1,8 @@
+#import <Foundation/Foundation.h>
+#import "Cedar.h"
+
+@interface CedarTestSpecBuilder : CDRSpec
+
+- (void)wrapWithDeclareBehaviors:(dispatch_block_t)block;
+
+@end

--- a/Spec/Support/CedarTestSpecBuilder.m
+++ b/Spec/Support/CedarTestSpecBuilder.m
@@ -1,0 +1,19 @@
+#import "CedarTestSpecBuilder.h"
+
+@interface CedarTestSpecBuilder ()
+@property dispatch_block_t block;
+@end
+
+@implementation CedarTestSpecBuilder
+
+- (void)wrapWithDeclareBehaviors:(dispatch_block_t)block {
+    self.block = block;
+}
+
+- (void)declareBehaviors {
+    if (self.block) {
+        self.block();
+    }
+}
+
+@end

--- a/Spec/XCTest/CDRXCTestSuiteSpec.mm
+++ b/Spec/XCTest/CDRXCTestSuiteSpec.mm
@@ -22,8 +22,11 @@ describe(@"CDRXCTestSuite", ^{
         reporter = [TestReporter new];
         dispatcher = [[CDRReportDispatcher alloc] initWithReporters:@[reporter]];
 
+        CDRDisableSpecValidation();
         CDRSpec *simulatedSpec = [[NSClassFromString(@"CDRXCSimulatedTestSuiteSpec") alloc] init];
         [simulatedSpec defineBehaviors];
+        CDREnableSpecValidation();
+
         subject = [simulatedSpec testSuiteWithRandomSeed:0 dispatcher:dispatcher];
         [subject performTest:nil];
     });


### PR DESCRIPTION
Fixes #394.

The first commit is the brunt of this feature work. DSL misuse encompasses two main failure modes:

* someone calls `it()`, `describe()`, or `context()` inside of an `it()` block
  * this would never work because the newly-added tests are never run
* someone tries to call any of the above functions outside of a test
  * this would never work because there is no spec yet to add them to until we build the tree

In writing this feature I tried to avoid adding much more scope to Cedar's public interface, but found it necessary to expose `CDRdisableSpecValidation()` and `CDRenableSpecValidation()` functions so that we could keep our existing tests that create cedar examples by calling `it()` inside of a test. I also thought it desirable to allow someone to disable this feature, if they were using Cedar in some interesting way.

Then, once I was totally done with this feature, writing a happy commit message and running all of the test suite ... I discovered a completely unrelated regression in the Type Utilities part of Cedar. The commit message for that is pretty verbose -- I recommend reading it if you want to know when a valid pointer sometimes can be misconstrued to be a NULL pointer. It was quite a find.