### PR TITLE
Fixed "This function declaration is not a prototype" errors in Xcode 9

### DIFF
--- a/Source/Headers/Public/CDRFunctions.h
+++ b/Source/Headers/Public/CDRFunctions.h
@@ -9,13 +9,13 @@ extern "C" {
 
 NSArray *CDRReportersFromEnv(const char*defaultReporterClassName);
 
-int CDRRunSpecs();
-OBJC_EXPORT void CDRInjectIntoXCTestRunner();
+int CDRRunSpecs(void);
+OBJC_EXPORT void CDRInjectIntoXCTestRunner(void);
 int CDRRunSpecsWithCustomExampleReporters(NSArray *reporters);
 NSArray *CDRShuffleItemsInArrayWithSeed(NSArray *sortedItems, unsigned int seed);
-NSArray *CDRReportersToRun();
-NSString *CDRGetTestBundleExtension();
-void CDRSuppressStandardPipesWhileLoadingClasses();
+NSArray *CDRReportersToRun(void);
+NSString *CDRGetTestBundleExtension(void);
+void CDRSuppressStandardPipesWhileLoadingClasses(void);
 
 NS_ASSUME_NONNULL_END
 

--- a/Source/Headers/Public/CDRSpec.h
+++ b/Source/Headers/Public/CDRSpec.h
@@ -37,8 +37,8 @@ CDRExample * fit(NSString *, __nullable CDRSpecBlock);
 
 void fail(NSString *);
 
-void CDREnableSpecValidation();
-void CDRDisableSpecValidation();
+void CDREnableSpecValidation(void);
+void CDRDisableSpecValidation(void);
 
 #ifdef __cplusplus
 }


### PR DESCRIPTION
Cedar's headers declare no-args functions in a way that means "this function takes no arguments" in C++ but "this function takes an unspecified number of arguments" in C and Objective-C. With the default project settings applied, Xcode treats those declarations as errors.